### PR TITLE
fix: provide options.key for the settings.plugin.item keyed slot

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1455,7 +1455,7 @@ function apply(ctx) {
     })
     ctx.slots.inject('settings.plugin.item', function () {
       return ctx.slots.register({
-        name: 'settings.plugin.item', id: 'dsh-pet-remielle', order: 30,
+        name: 'settings.plugin.item', id: 'dsh-pet-remielle', key: 'dsh-pet-remielle', order: 30,
         inject: function () { return {} },
       }, RemielleCard)
     })

--- a/src/client.core.js
+++ b/src/client.core.js
@@ -1451,7 +1451,7 @@ function apply(ctx) {
     })
     ctx.slots.inject('settings.plugin.item', function () {
       return ctx.slots.register({
-        name: 'settings.plugin.item', id: 'dsh-pet-remielle', order: 30,
+        name: 'settings.plugin.item', id: 'dsh-pet-remielle', key: 'dsh-pet-remielle', order: 30,
         inject: function () { return {} },
       }, RemielleCard)
     })


### PR DESCRIPTION
## 修复：`settings.plugin.item` keyed slot 注册补上 `key`

### 问题

DSH 0.1.0-rc.6/rc.7 起，keyed slot 的加载期校验强制要求 `options.key`。本插件的浏览器端卡片注册（`src/client.core.js` 的 `apply()`）在向 `settings.plugin.item` 注册时漏了 `key`，导致启动即失败：

```
Failed to load plugins
dsh-pet-remielle
failed to apply loader entry 593ad50f (dsh-pet-remielle): keyed slot "settings.plugin.item" requires options.key
```

见 #3（0.3.0 同样报错）。

### 修复内容

`src/client.core.js`：

```diff
-        name: 'settings.plugin.item', id: 'dsh-pet-remielle', order: 30,
+        name: 'settings.plugin.item', id: 'dsh-pet-remielle', key: 'dsh-pet-remielle', order: 30,
```

`key` 就是插件 host 侧注册的 settings 命名空间（`src/index.js` 中 `PLUGIN_KEY = 'dsh-pet-remielle'`、`ctx.settings.register(PLUGIN_KEY, ...)`），与 DSH 官方 `dsh-client-ui-settings-plugins` 的注册写法（`key: SHELL_NS`）一致。

`lib/client.js` 为构建产物，已用 `npm run build:client` 重新生成。

### 验证

- 未修复：`apply()` 抛出与报错完全一致的 `keyed slot "settings.plugin.item" requires options.key`。
- 修复后：两条注册（`settings.section` id `pets`、`settings.plugin.item` key `dsh-pet-remielle`）均通过校验。
- `node --check` 语法检查通过。

Closes #3
