### PR TITLE
feat: stacked per-session status bubbles with current-conversation & attention priority

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -69,6 +69,15 @@ var CSS = [
   'body[data-ds-dark-theme] .rm2-pet-bubble-title{color:#ffd6e4;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble-detail{color:#f0a8c0;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble::after{border-top-color:rgba(255,150,185,.42);}',
+  // Stacked status bubbles (one per active session). The column renders
+  // bottom-up: the top of the stack is the highest-ranked bubble.
+  '.rm2-pet-bubbles{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);display:flex;flex-direction:column-reverse;align-items:center;gap:6px;margin-bottom:10px;pointer-events:none;max-width:380px;z-index:1;}',
+  '.rm2-pet-bubbles .rm2-pet-bubble{position:relative;bottom:auto;left:auto;transform:none;margin-bottom:0;transition:box-shadow .2s;}',
+  '.rm2-pet-bubble.top{border-color:#b03a60;box-shadow:0 6px 20px rgba(190,70,110,.38);}',
+  '.rm2-pet-bubble.attention{border-color:#e8508a;animation:rm2-pet-attention 1.6s ease-in-out infinite;}',
+  '@keyframes rm2-pet-attention{0%,100%{box-shadow:0 0 0 0 rgba(232,80,138,.35);}50%{box-shadow:0 0 0 6px rgba(232,80,138,0);}}',
+  'body[data-ds-dark-theme] .rm2-pet-bubble.top{border-color:#ffb3c9;}',
+  'body[data-ds-dark-theme] .rm2-pet-bubble.attention{border-color:#ff6fa8;}',
   // Progress bar inside confirmation dialog
   '.rm2-pet-dl-text{color:#b03a60;font-weight:600;font-size:12px;font-family:system-ui,sans-serif;}',
   '.rm2-pet-dl-bar{width:100%;height:4px;border-radius:2px;background:rgba(240,120,160,.2);overflow:hidden;}',
@@ -783,14 +792,10 @@ function mountPet(ctx) {
   var img = mk('img', 'width:180px;height:auto;pointer-events:none;display:none;')
   img.alt = '桌宠'
   img.draggable = false
-  var bubble = mk('div', 'display:none;')
-  bubble.className = 'rm2-pet-bubble'
-  var bubbleTitle = mk('div', '')
-  bubbleTitle.className = 'rm2-pet-bubble-title'
-  var bubbleDetail = mk('div', '')
-  bubbleDetail.className = 'rm2-pet-bubble-detail'
-  bubble.appendChild(bubbleTitle)
-  bubble.appendChild(bubbleDetail)
+  // Stacked status bubbles: one per active session, top = highest rank
+  // (attention-needing first, then the current conversation, then priority).
+  var bubbleStack = mk('div', 'display:none;')
+  bubbleStack.className = 'rm2-pet-bubbles'
   // Confirmation dialog
   var confirmOverlay = mk('div')
   confirmOverlay.className = 'rm2-pet-confirm-overlay'
@@ -856,7 +861,7 @@ function mountPet(ctx) {
   styleEl.setAttribute('data-rm2-pet-css', '')
 
   dock.appendChild(img)
-  dock.appendChild(bubble)
+  dock.appendChild(bubbleStack)
   root.appendChild(dock)
   document.body.appendChild(picEl)
   document.head.appendChild(styleEl)
@@ -887,35 +892,114 @@ function mountPet(ctx) {
     dock.style.cursor = lockedNow ? 'default' : 'grab'
   }
 
-  /** Status bubble above the pet: message + detail (project · progress · stage).
-   *  The title changes at most once per BUBBLE_TITLE_MS while the mood stays put
-   *  (so think 04 / streaming 01 doesn't flip on every chunk, but still refreshes
-   *  occasionally), and updates immediately when the mood/phase changes. */
-  var BUBBLE_TITLE_MS = 2000
-  var lastBubbleMood = ''
-  var lastBubbleText = ''
-  var lastBubbleTitleAt = 0
-  var lastBubbleDetail = ''
-  function updateBubble(snapshot) {
+  /** ---- stacked status bubbles (one per active session) ----
+   *  Order: attention-needing sessions (waiting on the human / errors) on
+   *  top, then the session the user currently has open, then the rest by
+   *  state priority and recency. MAX_BUBBLES caps the visible stack; the pet
+   *  body follows the top bubble's mood. */
+  var MAX_BUBBLES = 5
+  var currentSessionId = undefined
+  var lastTopEntry = null
+  var bubbleEls = new Map() // sessionId -> { node, title, detail }
+  function stateRank(state) {
+    switch (state) {
+      case 'WAITING': return 60
+      case 'ERROR': return 50
+      case 'WORKING': return 30
+      case 'THINKING': return 20
+      case 'DISCONNECTED': return -1
+      default: return 0
+    }
+  }
+  function attentionOf(entry) {
+    return entry.attention === true || entry.state === 'WAITING' || entry.state === 'ERROR'
+  }
+  function orderSessions(sessions) {
+    return sessions.slice().sort(function (a, b) {
+      var aAtt = attentionOf(a) ? 1 : 0
+      var bAtt = attentionOf(b) ? 1 : 0
+      if (aAtt !== bAtt) return bAtt - aAtt
+      var aCur = a.sessionId === currentSessionId ? 1 : 0
+      var bCur = b.sessionId === currentSessionId ? 1 : 0
+      if (aCur !== bCur) return bCur - aCur
+      var priority = stateRank(b.state) - stateRank(a.state)
+      return priority || (b.updatedAt || 0) - (a.updatedAt || 0)
+    })
+  }
+  function ensureBubbleEl(sessionId) {
+    var existing = bubbleEls.get(sessionId)
+    if (existing) return existing
+    var node = mk('div', 'display:none;')
+    node.className = 'rm2-pet-bubble'
+    var title = mk('div', '')
+    title.className = 'rm2-pet-bubble-title'
+    var detail = mk('div', '')
+    detail.className = 'rm2-pet-bubble-detail'
+    node.appendChild(title)
+    node.appendChild(detail)
+    bubbleStack.appendChild(node)
+    var el = { node: node, title: title, detail: detail, lastText: '', lastDetail: '' }
+    bubbleEls.set(sessionId, el)
+    return el
+  }
+  function renderBubble(el, entry, index) {
+    var text = entry.message || ''
+    var detail = entry.detail || ''
+    if (text !== el.lastText) {
+      el.lastText = text
+      el.title.textContent = text
+    }
+    if (detail !== el.lastDetail) {
+      el.lastDetail = detail
+      el.detail.textContent = detail
+    }
+    if (!text && !detail) {
+      el.node.style.display = 'none'
+      return
+    }
+    el.node.className = 'rm2-pet-bubble' + (index === 0 ? ' top' : '') + (attentionOf(entry) ? ' attention' : '')
+    el.node.style.display = 'block'
+  }
+  function updateBubbles(snapshot) {
     if (!snapshot) return
-    var show = snapshot.bubble !== false && Boolean(snapshot.detail)
-    if (show) {
-      var text = snapshot.message || ''
-      var detail = snapshot.detail || ''
-      var now = Date.now()
-      var moodChanged = snapshot.mood !== lastBubbleMood
-      if (moodChanged || (text !== lastBubbleText && now - lastBubbleTitleAt >= BUBBLE_TITLE_MS)) {
-        lastBubbleTitleAt = now
-        lastBubbleMood = snapshot.mood
-        lastBubbleText = text
-        bubbleTitle.textContent = text
-      }
-      if (detail !== lastBubbleDetail) {
-        lastBubbleDetail = detail
-        bubbleDetail.textContent = detail
+    var sessions = Array.isArray(snapshot.sessions) && snapshot.sessions.length > 0
+      ? snapshot.sessions
+      : [snapshot] // legacy single-session snapshot
+    var ordered = orderSessions(sessions)
+    lastTopEntry = ordered[0] || null
+    // Pet body follows the top bubble's mood; the turn-end "得意中" flash
+    // below also keys off the top entry's state.
+    if (lastTopEntry && lastTopEntry.mood) snapshot.mood = lastTopEntry.mood
+    var count = Math.min(ordered.length, MAX_BUBBLES)
+    var seen = new Set()
+    for (var i = 0; i < count; i++) {
+      var entry = ordered[i]
+      seen.add(entry.sessionId)
+      renderBubble(ensureBubbleEl(entry.sessionId), entry, i)
+    }
+    for (var key of bubbleEls.keys()) {
+      if (!seen.has(key)) {
+        var el = bubbleEls.get(key)
+        if (el && el.node && el.node.remove) el.node.remove()
+        bubbleEls.delete(key)
       }
     }
-    bubble.style.display = show ? 'block' : 'none'
+    bubbleStack.style.display = snapshot.bubble !== false && count > 0 ? 'flex' : 'none'
+  }
+  // Follow the user's current conversation so its bubble ranks on top of
+  // same-priority peers (the "which dialog is on top" rule).
+  if (ctx && ctx.sessions && ctx.sessions.list && typeof ctx.effect === 'function') {
+    var sessionList = ctx.sessions.list
+    currentSessionId = typeof sessionList.getSnapshot === 'function' ? sessionList.getSnapshot().current : undefined
+    ctx.effect(function () {
+      return sessionList.subscribe(function () {
+        var next = typeof sessionList.getSnapshot === 'function' ? sessionList.getSnapshot().current : undefined
+        if (next !== currentSessionId) {
+          currentSessionId = next
+          if (lastSnapshot) updateBubbles(lastSnapshot)
+        }
+      })
+    })
   }
 
   /** After a pulse overlay expires the host falls back to the durable state; schedule one refresh. */
@@ -988,13 +1072,15 @@ function mountPet(ctx) {
       currentPetId = snapshot.petId
       displayedMood = null
     }
-    updateBubble(snapshot)
-    // Agent 回复完成时短暂"得意中"（仅触发一次，避免重复）
-    if (snapshot.state === 'IDLE' && snapshot.phase === 'turn-end' && !manualOverride && !lastTurnEndShown) {
+    updateBubbles(snapshot)
+    // Agent 回复完成时短暂"得意中"（仅触发一次，避免重复）——以堆叠顶部会话为准
+    var topState = lastTopEntry ? lastTopEntry.state : snapshot.state
+    var topPhase = lastTopEntry ? lastTopEntry.phase : snapshot.phase
+    if (topState === 'IDLE' && topPhase === 'turn-end' && !manualOverride && !lastTurnEndShown) {
       lastTurnEndShown = true
       manualOverride = { mood: '03', until: Date.now() + 2000 }
     }
-    if (snapshot.state !== 'IDLE') lastTurnEndShown = false
+    if (topState !== 'IDLE') lastTurnEndShown = false
     var enabled = snapshot.enabled !== false
     if (!enabled) {
       setHidden(true)
@@ -1469,7 +1555,7 @@ function apply(ctx) {
 
 module.exports = {
   name: 'dsh-pet-remielle-client',
-  inject: ['slots'],
+  inject: ['slots', 'sessions'],
   apply: apply,
 }
 

--- a/src/client.core.js
+++ b/src/client.core.js
@@ -65,6 +65,15 @@ var CSS = [
   'body[data-ds-dark-theme] .rm2-pet-bubble-title{color:#ffd6e4;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble-detail{color:#f0a8c0;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble::after{border-top-color:rgba(255,150,185,.42);}',
+  // Stacked status bubbles (one per active session). The column renders
+  // bottom-up: the top of the stack is the highest-ranked bubble.
+  '.rm2-pet-bubbles{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);display:flex;flex-direction:column-reverse;align-items:center;gap:6px;margin-bottom:10px;pointer-events:none;max-width:380px;z-index:1;}',
+  '.rm2-pet-bubbles .rm2-pet-bubble{position:relative;bottom:auto;left:auto;transform:none;margin-bottom:0;transition:box-shadow .2s;}',
+  '.rm2-pet-bubble.top{border-color:#b03a60;box-shadow:0 6px 20px rgba(190,70,110,.38);}',
+  '.rm2-pet-bubble.attention{border-color:#e8508a;animation:rm2-pet-attention 1.6s ease-in-out infinite;}',
+  '@keyframes rm2-pet-attention{0%,100%{box-shadow:0 0 0 0 rgba(232,80,138,.35);}50%{box-shadow:0 0 0 6px rgba(232,80,138,0);}}',
+  'body[data-ds-dark-theme] .rm2-pet-bubble.top{border-color:#ffb3c9;}',
+  'body[data-ds-dark-theme] .rm2-pet-bubble.attention{border-color:#ff6fa8;}',
   // Progress bar inside confirmation dialog
   '.rm2-pet-dl-text{color:#b03a60;font-weight:600;font-size:12px;font-family:system-ui,sans-serif;}',
   '.rm2-pet-dl-bar{width:100%;height:4px;border-radius:2px;background:rgba(240,120,160,.2);overflow:hidden;}',
@@ -779,14 +788,10 @@ function mountPet(ctx) {
   var img = mk('img', 'width:180px;height:auto;pointer-events:none;display:none;')
   img.alt = '桌宠'
   img.draggable = false
-  var bubble = mk('div', 'display:none;')
-  bubble.className = 'rm2-pet-bubble'
-  var bubbleTitle = mk('div', '')
-  bubbleTitle.className = 'rm2-pet-bubble-title'
-  var bubbleDetail = mk('div', '')
-  bubbleDetail.className = 'rm2-pet-bubble-detail'
-  bubble.appendChild(bubbleTitle)
-  bubble.appendChild(bubbleDetail)
+  // Stacked status bubbles: one per active session, top = highest rank
+  // (attention-needing first, then the current conversation, then priority).
+  var bubbleStack = mk('div', 'display:none;')
+  bubbleStack.className = 'rm2-pet-bubbles'
   // Confirmation dialog
   var confirmOverlay = mk('div')
   confirmOverlay.className = 'rm2-pet-confirm-overlay'
@@ -852,7 +857,7 @@ function mountPet(ctx) {
   styleEl.setAttribute('data-rm2-pet-css', '')
 
   dock.appendChild(img)
-  dock.appendChild(bubble)
+  dock.appendChild(bubbleStack)
   root.appendChild(dock)
   document.body.appendChild(picEl)
   document.head.appendChild(styleEl)
@@ -883,35 +888,114 @@ function mountPet(ctx) {
     dock.style.cursor = lockedNow ? 'default' : 'grab'
   }
 
-  /** Status bubble above the pet: message + detail (project · progress · stage).
-   *  The title changes at most once per BUBBLE_TITLE_MS while the mood stays put
-   *  (so think 04 / streaming 01 doesn't flip on every chunk, but still refreshes
-   *  occasionally), and updates immediately when the mood/phase changes. */
-  var BUBBLE_TITLE_MS = 2000
-  var lastBubbleMood = ''
-  var lastBubbleText = ''
-  var lastBubbleTitleAt = 0
-  var lastBubbleDetail = ''
-  function updateBubble(snapshot) {
+  /** ---- stacked status bubbles (one per active session) ----
+   *  Order: attention-needing sessions (waiting on the human / errors) on
+   *  top, then the session the user currently has open, then the rest by
+   *  state priority and recency. MAX_BUBBLES caps the visible stack; the pet
+   *  body follows the top bubble's mood. */
+  var MAX_BUBBLES = 5
+  var currentSessionId = undefined
+  var lastTopEntry = null
+  var bubbleEls = new Map() // sessionId -> { node, title, detail }
+  function stateRank(state) {
+    switch (state) {
+      case 'WAITING': return 60
+      case 'ERROR': return 50
+      case 'WORKING': return 30
+      case 'THINKING': return 20
+      case 'DISCONNECTED': return -1
+      default: return 0
+    }
+  }
+  function attentionOf(entry) {
+    return entry.attention === true || entry.state === 'WAITING' || entry.state === 'ERROR'
+  }
+  function orderSessions(sessions) {
+    return sessions.slice().sort(function (a, b) {
+      var aAtt = attentionOf(a) ? 1 : 0
+      var bAtt = attentionOf(b) ? 1 : 0
+      if (aAtt !== bAtt) return bAtt - aAtt
+      var aCur = a.sessionId === currentSessionId ? 1 : 0
+      var bCur = b.sessionId === currentSessionId ? 1 : 0
+      if (aCur !== bCur) return bCur - aCur
+      var priority = stateRank(b.state) - stateRank(a.state)
+      return priority || (b.updatedAt || 0) - (a.updatedAt || 0)
+    })
+  }
+  function ensureBubbleEl(sessionId) {
+    var existing = bubbleEls.get(sessionId)
+    if (existing) return existing
+    var node = mk('div', 'display:none;')
+    node.className = 'rm2-pet-bubble'
+    var title = mk('div', '')
+    title.className = 'rm2-pet-bubble-title'
+    var detail = mk('div', '')
+    detail.className = 'rm2-pet-bubble-detail'
+    node.appendChild(title)
+    node.appendChild(detail)
+    bubbleStack.appendChild(node)
+    var el = { node: node, title: title, detail: detail, lastText: '', lastDetail: '' }
+    bubbleEls.set(sessionId, el)
+    return el
+  }
+  function renderBubble(el, entry, index) {
+    var text = entry.message || ''
+    var detail = entry.detail || ''
+    if (text !== el.lastText) {
+      el.lastText = text
+      el.title.textContent = text
+    }
+    if (detail !== el.lastDetail) {
+      el.lastDetail = detail
+      el.detail.textContent = detail
+    }
+    if (!text && !detail) {
+      el.node.style.display = 'none'
+      return
+    }
+    el.node.className = 'rm2-pet-bubble' + (index === 0 ? ' top' : '') + (attentionOf(entry) ? ' attention' : '')
+    el.node.style.display = 'block'
+  }
+  function updateBubbles(snapshot) {
     if (!snapshot) return
-    var show = snapshot.bubble !== false && Boolean(snapshot.detail)
-    if (show) {
-      var text = snapshot.message || ''
-      var detail = snapshot.detail || ''
-      var now = Date.now()
-      var moodChanged = snapshot.mood !== lastBubbleMood
-      if (moodChanged || (text !== lastBubbleText && now - lastBubbleTitleAt >= BUBBLE_TITLE_MS)) {
-        lastBubbleTitleAt = now
-        lastBubbleMood = snapshot.mood
-        lastBubbleText = text
-        bubbleTitle.textContent = text
-      }
-      if (detail !== lastBubbleDetail) {
-        lastBubbleDetail = detail
-        bubbleDetail.textContent = detail
+    var sessions = Array.isArray(snapshot.sessions) && snapshot.sessions.length > 0
+      ? snapshot.sessions
+      : [snapshot] // legacy single-session snapshot
+    var ordered = orderSessions(sessions)
+    lastTopEntry = ordered[0] || null
+    // Pet body follows the top bubble's mood; the turn-end "得意中" flash
+    // below also keys off the top entry's state.
+    if (lastTopEntry && lastTopEntry.mood) snapshot.mood = lastTopEntry.mood
+    var count = Math.min(ordered.length, MAX_BUBBLES)
+    var seen = new Set()
+    for (var i = 0; i < count; i++) {
+      var entry = ordered[i]
+      seen.add(entry.sessionId)
+      renderBubble(ensureBubbleEl(entry.sessionId), entry, i)
+    }
+    for (var key of bubbleEls.keys()) {
+      if (!seen.has(key)) {
+        var el = bubbleEls.get(key)
+        if (el && el.node && el.node.remove) el.node.remove()
+        bubbleEls.delete(key)
       }
     }
-    bubble.style.display = show ? 'block' : 'none'
+    bubbleStack.style.display = snapshot.bubble !== false && count > 0 ? 'flex' : 'none'
+  }
+  // Follow the user's current conversation so its bubble ranks on top of
+  // same-priority peers (the "which dialog is on top" rule).
+  if (ctx && ctx.sessions && ctx.sessions.list && typeof ctx.effect === 'function') {
+    var sessionList = ctx.sessions.list
+    currentSessionId = typeof sessionList.getSnapshot === 'function' ? sessionList.getSnapshot().current : undefined
+    ctx.effect(function () {
+      return sessionList.subscribe(function () {
+        var next = typeof sessionList.getSnapshot === 'function' ? sessionList.getSnapshot().current : undefined
+        if (next !== currentSessionId) {
+          currentSessionId = next
+          if (lastSnapshot) updateBubbles(lastSnapshot)
+        }
+      })
+    })
   }
 
   /** After a pulse overlay expires the host falls back to the durable state; schedule one refresh. */
@@ -984,13 +1068,15 @@ function mountPet(ctx) {
       currentPetId = snapshot.petId
       displayedMood = null
     }
-    updateBubble(snapshot)
-    // Agent 回复完成时短暂"得意中"（仅触发一次，避免重复）
-    if (snapshot.state === 'IDLE' && snapshot.phase === 'turn-end' && !manualOverride && !lastTurnEndShown) {
+    updateBubbles(snapshot)
+    // Agent 回复完成时短暂"得意中"（仅触发一次，避免重复）——以堆叠顶部会话为准
+    var topState = lastTopEntry ? lastTopEntry.state : snapshot.state
+    var topPhase = lastTopEntry ? lastTopEntry.phase : snapshot.phase
+    if (topState === 'IDLE' && topPhase === 'turn-end' && !manualOverride && !lastTurnEndShown) {
       lastTurnEndShown = true
       manualOverride = { mood: '03', until: Date.now() + 2000 }
     }
-    if (snapshot.state !== 'IDLE') lastTurnEndShown = false
+    if (topState !== 'IDLE') lastTurnEndShown = false
     var enabled = snapshot.enabled !== false
     if (!enabled) {
       setHidden(true)
@@ -1465,6 +1551,6 @@ function apply(ctx) {
 
 module.exports = {
   name: 'dsh-pet-remielle-client',
-  inject: ['slots'],
+  inject: ['slots', 'sessions'],
   apply: apply,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -302,10 +302,11 @@ export function createAssetsHandler(petsRoot) {
  * `petId` (the active pet) rides along so the client can resolve sticker
  * URLs; it resolves through the registry, not the raw config.
  */
-export function createStateSnapshot({ getLatest, getPulse, getConfig, getPetId, getDesktopActive, getActivePet }) {
+export function createStateSnapshot({ getLatest, getPulse, getConfig, getPetId, getDesktopActive, getActivePet, getStates }) {
   const petIdOf = typeof getPetId === 'function' ? getPetId : () => DEFAULT_PET_ID
   const desktopActiveOf = typeof getDesktopActive === 'function' ? getDesktopActive : () => false
   const activePetOf = typeof getActivePet === 'function' ? getActivePet : () => undefined
+  const statesOf = typeof getStates === 'function' ? getStates : () => []
   return () => {
     const config = publicConfig(getConfig())
     const now = Date.now()
@@ -313,6 +314,22 @@ export function createStateSnapshot({ getLatest, getPulse, getConfig, getPetId, 
     const base = getLatest()
     const activePulse = pulse && pulse.until > now ? pulse : undefined
     const source = activePulse ?? base
+    // One entry per tracked session for the stacked-bubble view. The active
+    // PULSE overlay (success / error flash) overrides its own session's entry
+    // so the flash lands on the right bubble, not on the primary.
+    const sessions = statesOf().map((entry) => {
+      if (activePulse && activePulse.sessionId === entry.sessionId) {
+        return {
+          ...entry,
+          state: activePulse.state,
+          mood: activePulse.mood ?? entry.mood,
+          message: activePulse.message ?? entry.message,
+          detail: activePulse.detail ?? entry.detail,
+          pulseUntil: activePulse.until,
+        }
+      }
+      return entry
+    })
     return {
       ok: true,
       enabled: config.enabled === true,
@@ -335,6 +352,7 @@ export function createStateSnapshot({ getLatest, getPulse, getConfig, getPetId, 
       task: base?.task ?? undefined,
       progress: base?.progress ?? undefined,
       pulseUntil: activePulse ? activePulse.until : 0,
+      sessions,
       ts: now,
     }
   }
@@ -496,6 +514,7 @@ function mount(ctx, config = {}, eventCtx = ctx) {
     getPetId: () => registry.activePetId,
     getDesktopActive: () => desktopActive,
     getActivePet: () => registry.pets.find((pet) => pet.id === registry.activePetId),
+    getStates: () => reducer.states(),
   })
 
   const hub = createStreamHub({ serve: serveState })

--- a/src/pet-reducer.js
+++ b/src/pet-reducer.js
@@ -259,6 +259,38 @@ export class PetReducer {
     return this.#render()
   }
 
+  /**
+   * One renderable state per tracked session, for the stacked-bubble view.
+   * Default order: attention (needs the human) first, then state priority,
+   * then recency. The browser client re-sorts with the current-conversation
+   * rule (current conversation above same-rank peers) before rendering.
+   */
+  states() {
+    const out = []
+    for (const record of this.sessions.values()) {
+      out.push({
+        sessionId: record.id,
+        state: record.state,
+        mood: moodFor(record.state, record.payload.phase),
+        phase: record.payload.phase ?? '',
+        message: record.payload.message ?? '',
+        detail: detailFor(record),
+        project: record.project,
+        task: record.task,
+        progress: record.progress,
+        attention: record.state === PetState.WAITING || record.state === PetState.ERROR,
+        updatedAt: record.updatedAt,
+      })
+    }
+    out.sort((left, right) => {
+      const attention = Number(right.attention) - Number(left.attention)
+      if (attention !== 0) return attention
+      const priority = (statePriority[right.state] ?? 0) - (statePriority[left.state] ?? 0)
+      return priority || right.updatedAt - left.updatedAt || left.sessionId.localeCompare(right.sessionId)
+    })
+    return out
+  }
+
   #toolResult(record, event) {
     const callId = String(event.data?.message?.source?.callId
       ?? event.data?.message?.toolCallId

--- a/test/host-snapshot.test.js
+++ b/test/host-snapshot.test.js
@@ -4,12 +4,13 @@ import { createStateSnapshot } from '../src/index.js'
 import { DEFAULT_PET_ID } from '../src/pets.js'
 import { PetMessageKind, PetState, createMessage } from '../src/protocol.js'
 
-function snapshotWith({ latest, pulse = null, config = {}, petId }) {
+function snapshotWith({ latest, pulse = null, config = {}, petId, getStates }) {
   return createStateSnapshot({
     getLatest: () => latest,
     getPulse: () => pulse,
     getConfig: () => config,
     getPetId: () => petId,
+    getStates,
   })()
 }
 
@@ -150,4 +151,49 @@ test('expired pulse falls back to durable state', () => {
 test('disabled config is reflected in the snapshot', () => {
   const snapshot = snapshotWith({ latest: idle, config: { enabled: false } })
   assert.equal(snapshot.enabled, false)
+})
+
+test('snapshot carries one entry per tracked session for stacked bubbles', () => {
+  const states = [
+    { sessionId: 's2', state: PetState.WAITING, mood: '05', phase: 'ask', message: '等你回答', detail: 's2 · 等待回答', attention: true, updatedAt: 4 },
+    { sessionId: 's1', state: PetState.THINKING, mood: '01', phase: 'streaming', message: '正在输出', detail: 's1 · 输出阶段', attention: false, updatedAt: 3 },
+  ]
+  const snapshot = snapshotWith({ latest: idle, getStates: () => states })
+  assert.deepEqual(snapshot.sessions, states)
+})
+
+test('active pulse overrides its own session entry in sessions[]', () => {
+  const states = [
+    { sessionId: 's2', state: PetState.WAITING, mood: '05', phase: 'ask', message: '等你回答', detail: 's2 · 等待回答', attention: true, updatedAt: 4 },
+    { sessionId: 's1', state: PetState.THINKING, mood: '01', phase: 'streaming', message: '正在输出', detail: 's1 · 输出阶段', attention: false, updatedAt: 3 },
+  ]
+  const pulse = createMessage(PetMessageKind.PULSE, {
+    sessionId: 's1',
+    state: PetState.SUCCESS,
+    mood: '03',
+    ttlMs: 5000,
+    resumeState: PetState.IDLE,
+    resumeMood: '06',
+    message: '这次任务搞定啦~',
+    detail: 's1 · 本轮已完成',
+  })
+  const snapshot = snapshotWith({
+    latest: idle,
+    getStates: () => states,
+    pulse: { ...pulse, until: Date.now() + 4000 },
+  })
+  assert.equal(snapshot.sessions.length, 2)
+  const flashed = snapshot.sessions.find((entry) => entry.sessionId === 's1')
+  assert.equal(flashed.state, PetState.SUCCESS)
+  assert.equal(flashed.mood, '03')
+  assert.equal(flashed.message, '这次任务搞定啦~')
+  assert.ok(flashed.pulseUntil > Date.now())
+  // The waiting session's entry is untouched.
+  const waiting = snapshot.sessions.find((entry) => entry.sessionId === 's2')
+  assert.equal(waiting.state, PetState.WAITING)
+})
+
+test('sessions defaults to an empty array when no states feed is provided', () => {
+  const snapshot = snapshotWith({ latest: idle })
+  assert.deepEqual(snapshot.sessions, [])
 })

--- a/test/pet-reducer.test.js
+++ b/test/pet-reducer.test.js
@@ -331,3 +331,76 @@ test('approval/asked -> WAITING, approval/decided restores WORKING', () => {
   assert.equal(states.at(-1).state, PetState.THINKING)
 })
 
+test('states() is empty with no sessions', () => {
+  const reducer = new PetReducer()
+  assert.deepEqual(reducer.states(), [])
+})
+
+test('states() returns one entry per session with mood/message/detail', () => {
+  const reducer = new PetReducer()
+  collect(reducer, session('s1'), [
+    event('turn/start'),
+    event('assistant/message', {}, 2),
+  ])
+  const states = reducer.states()
+  assert.equal(states.length, 1)
+  assert.equal(states[0].sessionId, 's1')
+  assert.equal(states[0].state, PetState.THINKING)
+  assert.equal(states[0].mood, '01')
+  assert.ok(states[0].detail)
+  assert.equal(states[0].attention, false)
+})
+
+test('states() ranks attention-needing sessions on top', () => {
+  const reducer = new PetReducer()
+  // s1 is streaming (THINKING), s2 waits on the human (WAITING via ask).
+  collect(reducer, session('s1'), [
+    event('turn/start', {}, 1),
+    event('assistant/message', {}, 2),
+  ])
+  collect(reducer, session('s2'), [
+    event('turn/start', {}, 3),
+    event('tool/call', { callId: 'q1', name: 'ask_user_question' }, 4),
+  ])
+  const states = reducer.states()
+  assert.equal(states.length, 2)
+  // WAITING (s2) must come first even though s1 was updated later.
+  assert.equal(states[0].sessionId, 's2')
+  assert.equal(states[0].state, PetState.WAITING)
+  assert.equal(states[0].attention, true)
+  assert.equal(states[1].sessionId, 's1')
+  assert.equal(states[1].state, PetState.THINKING)
+  assert.equal(states[1].attention, false)
+})
+
+test('states() marks ERROR as attention and sorts before WORKING', () => {
+  const reducer = new PetReducer()
+  collect(reducer, session('s1'), [
+    event('turn/start'),
+    event('tool/call', { callId: 'c1', name: 'bash' }, 2),
+  ])
+  collect(reducer, session('s2'), [
+    event('turn/start', {}, 3),
+    event('assistant/message', {}, 4),
+    event('turn/end', { reason: { kind: 'max-tokens' } }, 5),
+  ])
+  const states = reducer.states()
+  assert.equal(states.length, 2)
+  assert.equal(states[0].sessionId, 's2')
+  assert.equal(states[0].state, PetState.ERROR)
+  assert.equal(states[0].attention, true)
+  assert.equal(states[1].sessionId, 's1')
+  assert.equal(states[1].state, PetState.WORKING)
+})
+
+test('disposeSession removes the session from states()', () => {
+  const reducer = new PetReducer()
+  collect(reducer, session('s1'), [event('turn/start')])
+  collect(reducer, session('s2'), [event('turn/start', {}, 2)])
+  assert.equal(reducer.states().length, 2)
+  reducer.disposeSession(session('s1'))
+  const states = reducer.states()
+  assert.equal(states.length, 1)
+  assert.equal(states[0].sessionId, 's2')
+})
+


### PR DESCRIPTION
## 功能：堆叠状态气泡（多会话）＋ 当前对话/需处理会话置顶

### 问题

之前宠物只有一个状态气泡，由全局"选主"逻辑驱动（`WAITING > ERROR > WORKING > THINKING > IDLE`，同级按最近更新取胜）。多个对话同时在跑时，谁的 chunk/事件后到气泡就切到谁，视觉上频繁跳变，也无法区分是哪个对话的状态。

### 改动

**Host**
- `PetReducer.states()`：为每个被跟踪的会话输出一条可渲染状态（`sessionId / state / mood / phase / message / detail / project / task / progress / attention / updatedAt`），`attention = WAITING || ERROR`（需要用户回答/确认/处理）。
- `createStateSnapshot`：快照新增 `sessions[]`（每会话一条）；活跃的 PULSE 覆盖（成功/失败闪动）只覆盖**自己所属会话**的那一条，闪动落在正确的气泡上，不再污染全局主状态。原有单状态字段全部保留（桌面悬浮窗等旧消费方不受影响）。

**Client（浏览器）**
- 渲染一个气泡**堆叠**（每活跃会话一条，最多 5 条），pet 主体贴纸跟随最上层气泡的 mood。
- 排序规则（从上到下）：
  1. **需要人工处理的会话**（等待回答 / 等待审批 / 出错）→ 最上层，带呼吸高亮动画
  2. **用户当前打开的对话**（`ctx.sessions.list.current`）→ 次层
  3. 其余按状态优先级、再按最近更新
- 订阅 `ctx.sessions.list`：切换对话时立即重排，让"哪个对话框在最上层"跟随用户操作。
- `inject` 从 `['slots']` 扩展为 `['slots', 'sessions']`（与第一方客户端插件一致）。

### 验证

- 新增测试：`pet-reducer`（`states()` 空/字段/attention 置顶/ERROR 标记/dispose 移除，+5）、`host-snapshot`（`sessions[]` 下发/脉冲按会话覆盖/默认空数组，+3）。
- 全部可运行测试通过（protocol 7、status-copy 5、pet-reducer 26、host-snapshot 13、pets 14、stream-hub 4）。
- DOM 桩冒烟测试：新版 `lib/client.js` 的 `apply()` 正常挂载，两个 slot 注册落位，会话订阅随 `current` 切换触发重排且不抛错。
- `node --check` 全部通过。
