### PR TITLE
fix(desktop): 离线打开 DSH 网页带上 0.1.2 启动 token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixes
+- 桌面离线打开 DSH 网页：有 `ctx.connection.authenticatedUrl` 时带上 0.1.2 进程 token，旧宿主仍打开 origin。
+
 ## [0.3.6] — 2026-08-22
 
 ### Features

--- a/src/desktop-window.js
+++ b/src/desktop-window.js
@@ -148,6 +148,7 @@ export function resolveBackend(options) {
 export class DesktopWindow {
   constructor({
     url,
+    webUrl,
     backend = resolveBackend(),
     parentPid = process.pid,
     logger = console,
@@ -156,6 +157,7 @@ export class DesktopWindow {
   } = {}) {
     if (!url) throw new Error('DesktopWindow requires a --url')
     this.url = url
+    this.webUrl = webUrl
     this.backend = backend
     this.parentPid = parentPid
     this.logger = logger
@@ -185,6 +187,7 @@ export class DesktopWindow {
         ...process.env,
         ELECTRON_RUN_AS_NODE: undefined,
         DSH_PET_URL: this.url + (this.url.includes('?') ? '&' : '?') + 'v=' + this.startNonce,
+        DSH_WEB_URL: this.webUrl || new URL('/', this.url).origin,
         DSH_PET_PARENT_PID: String(this.parentPid),
       },
     })

--- a/src/index.js
+++ b/src/index.js
@@ -930,7 +930,15 @@ function mount(ctx, config = {}, eventCtx = ctx) {
           hub.broadcast()
         }
       }
-      const desktopUrl = `http://127.0.0.1:${port}${PET_VIEW_ENDPOINT}`
+      const origin = `http://127.0.0.1:${port}`
+      const desktopUrl = `${origin}${PET_VIEW_ENDPOINT}`
+      // DSH 0.1.2-alpha.1 起 Web 壳根路径要带进程 token；旧宿主没有该方法则仍打开 origin。
+      const dshWebUrl = () => {
+        const connection = ctx.connection
+        return typeof connection?.authenticatedUrl === 'function'
+          ? connection.authenticatedUrl(origin)
+          : origin
+      }
       const onDesktopExit = () => {
         desktop = undefined
         if (desktopActive) { desktopActive = false; hub.broadcast() }
@@ -945,7 +953,7 @@ function mount(ctx, config = {}, eventCtx = ctx) {
         if (!allowFetch && settings.get().desktopMode === false) return
         /** Create a DesktopWindow, attach it, and broadcast state. */
         const spawnWindow = () => {
-          const w = new DesktopWindow({ url: desktopUrl, logger, onExit: onDesktopExit })
+          const w = new DesktopWindow({ url: desktopUrl, webUrl: dshWebUrl(), logger, onExit: onDesktopExit })
           if (!w.backend) return false
           desktop = w
           w.start()
@@ -1003,7 +1011,7 @@ function mount(ctx, config = {}, eventCtx = ctx) {
             // find the freshly installed runtime in time.
             const petWindowCjs = new URL('../src/pet-window.cjs', import.meta.url)
             const backend = { kind: 'electron', command: exe, args: [petWindowCjs.href.startsWith('file://') ? fileURLToPath(petWindowCjs) : String(petWindowCjs)] }
-            const w = new DesktopWindow({ url: desktopUrl, logger, onExit: onDesktopExit, backend })
+            const w = new DesktopWindow({ url: desktopUrl, webUrl: dshWebUrl(), logger, onExit: onDesktopExit, backend })
             desktop = w
             w.start()
             if (!desktopActive) { desktopActive = true; hub.broadcast() }

--- a/src/pet-window.cjs
+++ b/src/pet-window.cjs
@@ -5,8 +5,8 @@
  * Windows (crashes with exit -1 during app startup), while .cjs works.
  *
  * Configuration arrives via environment variables (DSH_PET_URL,
- * DSH_PET_PARENT_PID): passing extra CLI args to a spawned Electron on
- * Windows crashes with exit -1, while env is stable.
+ * DSH_WEB_URL, DSH_PET_PARENT_PID): passing extra CLI args to a spawned
+ * Electron on Windows crashes with exit -1, while env is stable.
  *
  * Creates a frameless, transparent, always-on-top window that loads the
  * plugin's pet-view page (pet GIF + status bubble over the SSE stream).
@@ -349,16 +349,14 @@ app.whenReady().then(() => {
     })
   })
 
-  // 无网页客户端在线时点击气泡卡：渲染层只发信号，URL 由这里从宿主给的
-  // DSH_PET_URL 推导（同源根路径即 DSH 网页端），用系统默认浏览器拉到前台。
-  // 已知限制：固定取 origin 根路径，若宿主部署在子路径（如 http://host/dsh/）
-  // 会落到错误页面；当前部署为根路径，待真有子路径需求再传 base path。
+  // 无网页客户端在线时点击气泡卡：渲染层只发信号，URL 由宿主经 DSH_WEB_URL
+  // 传入（DSH 0.1.2+ 为带进程 token 的根路径；旧宿主为 origin）。
+  // 用 href 而不是 origin：token 在 query 上，303 换 cookie 时也会丢掉其它参数。
   ipcMain.handle('open-dsh-page', () => {
     try {
-      const target = new URL('/', url)
-      // 只放行 http(s)：DSH_PET_URL 异常时不把其他协议的 URL 交给系统浏览器
+      const target = new URL(process.env.DSH_WEB_URL || new URL('/', url).origin)
       if (target.protocol !== 'http:' && target.protocol !== 'https:') return false
-      return shell.openExternal(target.origin)
+      return shell.openExternal(target.href)
     } catch {
       return Promise.resolve(false)
     }

--- a/test/desktop-window.test.js
+++ b/test/desktop-window.test.js
@@ -78,10 +78,32 @@ test('DesktopWindow start spawns electron with env config', () => {
   assert.equal(spawned.options.windowsHide, false)
   assert.ok(spawned.options.env.DSH_PET_URL.startsWith('http://127.0.0.1:50336/plugins/dsh-pet-remielle/pet-view'))
   assert.ok(spawned.options.env.DSH_PET_URL.includes('v='))
+  assert.equal(spawned.options.env.DSH_WEB_URL, 'http://127.0.0.1:50336')
   assert.equal(spawned.options.env.DSH_PET_PARENT_PID, '1234')
   assert.equal(window.running, true)
   window.stop()
   assert.equal(window.running, false)
+})
+
+test('DesktopWindow start passes DSH_WEB_URL when provided', () => {
+  let spawned = null
+  const window = new DesktopWindow({
+    url: 'http://127.0.0.1:50336/plugins/dsh-pet-remielle/pet-view',
+    webUrl: 'http://127.0.0.1:50336/?token=launch-token',
+    backend: { kind: 'electron', command: 'D:/plugins/vendor/electron-win32-x64/electron.exe', args: ['D:/plugins/src/pet-window.cjs'] },
+    spawnImpl: (command, args, options) => {
+      spawned = { command, args, options }
+      const child = new EventEmitter()
+      child.exitCode = null
+      child.killed = false
+      child.kill = () => { child.killed = true }
+      return child
+    },
+  })
+  window.start()
+  assert.equal(spawned.options.env.DSH_WEB_URL, 'http://127.0.0.1:50336/?token=launch-token')
+  assert.ok(spawned.options.env.DSH_PET_URL.startsWith('http://127.0.0.1:50336/plugins/dsh-pet-remielle/pet-view'))
+  window.stop()
 })
 
 test('DesktopWindow without a backend stays inert', () => {


### PR DESCRIPTION
## 背景

DSH [`0.1.2-alpha.1`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 起，Web 壳干净根路径会 401，必须带进程 `?token=` 才会 303 换成 cookie。0.3.6 桌面模式在无网页客户端时点气泡卡，会用系统浏览器打开 origin 根路径，升到该 DSH 后这条兜底会停在 401。

插件自有 `/plugins/dsh-pet-remielle/*` 不受这层鉴权；本 PR 只改「拉起 Web 壳」这一条路径。

关联 #13。

## 改动

- `src/index.js`：spawn 时 duck-type `ctx.connection.authenticatedUrl(origin)`；旧宿主没有该方法则仍用 origin。不把 `connection` 加进 inject。
- `src/desktop-window.js`：env 增加 `DSH_WEB_URL`（缺省回落到 pet URL 的 origin）。token **不**拼进 `DSH_PET_URL`。
- `src/pet-window.cjs`：`open-dsh-page` 改为 `openExternal(DSH_WEB_URL)`，用 `href` 保留 query。
- 单测锁：未传 `webUrl` 时 `DSH_WEB_URL` 为 origin；传入带 token 的 URL 时原样下发。

## 兼容

当前 npm latest 仍是 DSH 0.1.1-rc.2。本补丁在旧宿主上行为与 0.3.6 相同，不要求先升 DSH。新宿主发包后即可带 token。

## 测试

```
node test/desktop-window.test.js
```

13 pass / 1 skip（无 bundled Electron 的环境用例，与本次无关）。

**未做 DSH 0.1.2-alpha.1 实机测试。** 该版本目前只在 GitHub 打了预发布标签，尚未发布到 npm（`@deepseek-ai/dsh` dist-tag latest 仍为 0.1.1-rc.2），本机无法用常规 `dsh` 升级路径挂上新宿主。因此：

- 已在 **0.1.1-rc.2** 契约下用单测锁 `DSH_WEB_URL` 的 origin 回落与显式 token URL 下发；
- **没有**在 0.1.2-alpha.1 上点过「无网页客户端 → 桌面气泡卡 → 系统浏览器」这条路径，也未验证 `authenticatedUrl()` 的实机返回值与 303 换 cookie。

请维护者若已从 tag 源码跑新宿主，帮忙看一眼浏览器打开的是否是 `/?token=…` 且能进 Web 壳。npm 发包后我可以补一轮实机。