### PR TITLE
Linux 适配 + fnOS/TRIM gateway 前缀路由桌宠贴图 404 修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ Thumbs.db
 # local test scratch
 .tmp/
 # Electron runtime is too large for Git (184MB exe exceeds GitHub's 100MB limit).
-# Get it from the release asset or unpack a stock Electron 33 win32-x64 build here
-# (folder name must stay 'electron-win32-x64'); without it desktop mode falls
-# back to the in-page pet, or set DSH_PET_ELECTRON to an existing Electron binary.
+# It is fetched on demand into a per-platform folder (electron-win32-x64,
+# electron-linux-x64, ...); without it desktop mode falls back to the in-page
+# pet, or set DSH_PET_ELECTRON to an existing Electron binary.
 vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - 桌面离线打开 DSH 网页：有 `ctx.connection.authenticatedUrl` 时带上 0.1.2 进程 token，旧宿主仍打开 origin。
+- fnOS/TRIM gateway 前缀路由（`/app/<id>/`）支持：dsh web 挂载在前缀下时，宿主桥接只改写 HTML 静态 `src`/`fetch`/`EventSource`/`<script src>`，运行时 JS 赋值的 `img.src`（贴纸、双击画画 pics、气泡卡 favicon）不被改写，请求落到 NAS 根路径 404 → 宠物贴图消失（只剩文字气泡）、气泡吞掉 pointer 事件导致拖不动。现从本 bundle 的 `<script>` 加载路径检测前缀（回退页面 path），所有运行时绝对路径带前缀；直连模式（无前缀）行为不变。
 
 ## [0.3.6] — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Features
+- Linux 适配：插件不再仅限 Windows（`os` 增加 `linux`、`cpu` 增加 `arm64`）。桌面浮窗运行时改为按平台/架构解析（vendor 目录、二进制名、zip 名、跨平台解压），Electron 缺失时仍回落页面内宠物；桌面窗 DPI 注册表读取仅在 Windows 生效，其它平台回退 Electron screen API。
+
 ### Fixes
 - 桌面离线打开 DSH 网页：有 `ctx.connection.authenticatedUrl` 时带上 0.1.2 进程 token，旧宿主仍打开 origin。
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -274,6 +274,29 @@ var STREAM_ENDPOINT = '/plugins/dsh-pet-remielle/stream'
 var POLL_MS = 800
 var STABLE_POLL_MS = 3000
 
+// Gateway-prefix detection (fnOS / TRIM app-center style mounting).
+// When the dsh web is served under a path prefix (e.g. /app/<appId>/ via the
+// NAS webui), the host rewrites static HTML src/href and intercepts
+// fetch/EventSource/script-src, but runtime DOM assignments like
+// img.src = '/plugins/...' are NOT rewritten and would 404 at the NAS root.
+// Detect the prefix from this bundle's own <script> load URL (the bridge
+// rewrites it when mounted), falling back to the page path; '' when served
+// directly (127.0.0.1:3080).
+var RM_GATEWAY_PREFIX = (function () {
+  try {
+    var scripts = document.querySelectorAll('script[src*="dsh-pet-remielle"]')
+    for (var i = 0; i < scripts.length; i++) {
+      var s = scripts[i].src || ''
+      var idx = s.indexOf('/plugins/dsh-pet-remielle/')
+      if (idx > 0) return s.slice(0, idx)
+    }
+    var m = (location.pathname || '').match(/^\/app\/[^/]+/)
+    if (m) return m[0]
+  } catch (e) { /* non-browser context */ }
+  return ''
+})()
+function withPrefix(p) { return RM_GATEWAY_PREFIX + p }
+
 var CSS = [
   // Right-click menu — pink palette, matching the status bubble on both the
   // in-page pet and the desktop window (hardcoded, not DSW vars).
@@ -377,9 +400,9 @@ function mk(tag, style, text) {
   return n
 }
 
-/** Sticker URL for one pet + mood, served by the host. */
+/** Sticker URL for one pet + mood, served by the host (gateway-prefix aware). */
 function gifUrl(petId, mood) {
-  return ASSETS_PREFIX + '/' + encodeURIComponent(petId) + '/' + mood + '.gif'
+  return withPrefix(ASSETS_PREFIX) + '/' + encodeURIComponent(petId) + '/' + mood + '.gif'
 }
 
 /** Quick semver-ish compare (strips leading v, numeric dot segments). */
@@ -1642,7 +1665,7 @@ function mountPet(ctx) {
     action.className = 'rm2-pet-bubble-action'
     action.setAttribute('aria-label', '蕾米埃尔桌宠')
     var brandImg = document.createElement('img')
-    brandImg.src = '/favicon.svg'
+    brandImg.src = withPrefix('/favicon.svg')
     brandImg.alt = ''
     action.appendChild(brandImg)
     var title = mk('div', '')
@@ -2358,7 +2381,7 @@ function mountPet(ctx) {
     var count = snap && snap.pics ? snap.pics : 0
     if (!count) return
     var n = Math.floor(Math.random() * count) + 1
-    var src = ASSETS_PREFIX + '/' + encodeURIComponent(currentPetId) + '/pics/' + n + '.png'
+    var src = withPrefix(ASSETS_PREFIX) + '/' + encodeURIComponent(currentPetId) + '/pics/' + n + '.png'
     // 连续双击：picStop 清掉上一轮的动画与全部定时器，立即开始新一轮
     picStop()
     // 并立即清空画布内容：新图尚未加载完成前不得残留显示上一幅

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "generate": "node scripts/build-client.mjs",
     "prepublishOnly": "node scripts/build-client.mjs",
     "version": "node scripts/build-client.mjs && git add lib/client.js",
-    "test": "node --test --test-timeout=10000 test/protocol.test.js test/status-copy.test.js test/pet-reducer.test.js test/turn-watchdog.test.js test/host-snapshot.test.js test/client-interactions.test.js test/pets.test.js test/stream-hub.test.js test/desktop-window.test.js test/self-update.test.js test/pet-tip.test.js",
-    "check": "node --check lib/client.js && node --check src/index.js && node --check src/pet-reducer.js && node --check src/session-order.cjs && node --check src/turn-watchdog.js && node --check src/protocol.js && node --check src/status-copy.js && node --check src/pets.js && node --check src/self-update.js && node --check src/desktop-window.js && node --check src/pet-tip.cjs && node --check scripts/build-client.mjs"
+    "test": "node --test --test-timeout=10000 test/protocol.test.js test/status-copy.test.js test/pet-reducer.test.js test/turn-watchdog.test.js test/host-snapshot.test.js test/client-interactions.test.js test/pets.test.js test/stream-hub.test.js test/desktop-window.test.js test/self-update.test.js test/pet-tip.test.js test/electron-fetch.test.js",
+    "check": "node --check lib/client.js && node --check src/index.js && node --check src/pet-reducer.js && node --check src/session-order.cjs && node --check src/turn-watchdog.js && node --check src/protocol.js && node --check src/status-copy.js && node --check src/pets.js && node --check src/self-update.js && node --check src/desktop-window.js && node --check src/electron-fetch.mjs && node --check src/pet-window.cjs && node --check src/pet-tip.cjs && node --check scripts/build-client.mjs"
   },
   "dependencies": {
     "@deepseek-ai/schemastery": "^3.18.1"
@@ -52,10 +52,12 @@
   },
   "license": "MIT",
   "os": [
-    "win32"
+    "win32",
+    "linux"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ],
   "author": "dsh-pet-remielle contributors",
   "keywords": [

--- a/src/client.core.js
+++ b/src/client.core.js
@@ -50,6 +50,29 @@ var STREAM_ENDPOINT = '/plugins/dsh-pet-remielle/stream'
 var POLL_MS = 800
 var STABLE_POLL_MS = 3000
 
+// Gateway-prefix detection (fnOS / TRIM app-center style mounting).
+// When the dsh web is served under a path prefix (e.g. /app/<appId>/ via the
+// NAS webui), the host rewrites static HTML src/href and intercepts
+// fetch/EventSource/script-src, but runtime DOM assignments like
+// img.src = '/plugins/...' are NOT rewritten and would 404 at the NAS root.
+// Detect the prefix from this bundle's own <script> load URL (the bridge
+// rewrites it when mounted), falling back to the page path; '' when served
+// directly (127.0.0.1:3080).
+var RM_GATEWAY_PREFIX = (function () {
+  try {
+    var scripts = document.querySelectorAll('script[src*="dsh-pet-remielle"]')
+    for (var i = 0; i < scripts.length; i++) {
+      var s = scripts[i].src || ''
+      var idx = s.indexOf('/plugins/dsh-pet-remielle/')
+      if (idx > 0) return s.slice(0, idx)
+    }
+    var m = (location.pathname || '').match(/^\/app\/[^/]+/)
+    if (m) return m[0]
+  } catch (e) { /* non-browser context */ }
+  return ''
+})()
+function withPrefix(p) { return RM_GATEWAY_PREFIX + p }
+
 var CSS = [
   // Right-click menu — pink palette, matching the status bubble on both the
   // in-page pet and the desktop window (hardcoded, not DSW vars).
@@ -153,9 +176,9 @@ function mk(tag, style, text) {
   return n
 }
 
-/** Sticker URL for one pet + mood, served by the host. */
+/** Sticker URL for one pet + mood, served by the host (gateway-prefix aware). */
 function gifUrl(petId, mood) {
-  return ASSETS_PREFIX + '/' + encodeURIComponent(petId) + '/' + mood + '.gif'
+  return withPrefix(ASSETS_PREFIX) + '/' + encodeURIComponent(petId) + '/' + mood + '.gif'
 }
 
 /** Quick semver-ish compare (strips leading v, numeric dot segments). */
@@ -1418,7 +1441,7 @@ function mountPet(ctx) {
     action.className = 'rm2-pet-bubble-action'
     action.setAttribute('aria-label', '蕾米埃尔桌宠')
     var brandImg = document.createElement('img')
-    brandImg.src = '/favicon.svg'
+    brandImg.src = withPrefix('/favicon.svg')
     brandImg.alt = ''
     action.appendChild(brandImg)
     var title = mk('div', '')
@@ -2134,7 +2157,7 @@ function mountPet(ctx) {
     var count = snap && snap.pics ? snap.pics : 0
     if (!count) return
     var n = Math.floor(Math.random() * count) + 1
-    var src = ASSETS_PREFIX + '/' + encodeURIComponent(currentPetId) + '/pics/' + n + '.png'
+    var src = withPrefix(ASSETS_PREFIX) + '/' + encodeURIComponent(currentPetId) + '/pics/' + n + '.png'
     // 连续双击：picStop 清掉上一轮的动画与全部定时器，立即开始新一轮
     picStop()
     // 并立即清空画布内容：新图尚未加载完成前不得残留显示上一幅

--- a/src/desktop-window.js
+++ b/src/desktop-window.js
@@ -24,9 +24,9 @@ import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { electronArtifact } from './electron-fetch.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
-const bundledElectron = resolve(here, '..', 'vendor', 'electron-win32-x64', 'electron.exe')
 
 /**
  * Walk up from `startDir` looking for a directory containing the given
@@ -89,9 +89,10 @@ export function backendCandidates({ platform = process.platform, cwd = process.c
     candidates.push({ kind: 'electron', command: process.env.DSH_PET_ELECTRON, args })
   }
 
-  // --- 2. Bundled vendor runtime (shipped with the plugin) ---
-  if (platform === 'win32' && existsSync(bundledElectron)) {
-    candidates.push({ kind: 'electron', command: bundledElectron, args })
+  // --- 2. Bundled vendor runtime (fetched on demand, per platform/arch) ---
+  const bundled = electronArtifact({ platform, arch: process.arch }).exe
+  if (existsSync(bundled)) {
+    candidates.push({ kind: 'electron', command: bundled, args })
   }
 
   // --- 3. npm global install — user ran `npm install -g electron` somewhere ---

--- a/src/desktop-window.js
+++ b/src/desktop-window.js
@@ -4,9 +4,10 @@
  *
  * Electron backends, in preference order:
  *   1. DSH_PET_ELECTRON env var override.
- *   2. The bundled Electron runtime (vendor/electron-win32-x64) — ships with
- *      the plugin, so every user (plain web DSH host included) gets the same
- *      floating window with browser-engine GIF animation.
+ *   2. The bundled Electron runtime (vendor/electron-<platform>-<arch>,
+ *      resolved per-platform/arch via electronArtifact, fetched on demand)
+ *      — so every user (plain web DSH host included) gets the same floating
+ *      window with browser-engine GIF animation.
  *   3. npm global install (`npm install -g electron`) — find via
  *      `npm prefix -g` → node_modules/electron/dist/.
  *   4. The dsh binary root (derived from process.argv[1]) →

--- a/src/electron-fetch.mjs
+++ b/src/electron-fetch.mjs
@@ -4,7 +4,11 @@
  * The floating desktop window needs a real Electron binary (~221MB, which is
  * why it is NOT bundled into the Git repo — see README "桌面模式运行时"). This
  * module lets the host fetch it automatically the first time desktop mode is
- * used, instead of making the user hunt down a 221MB zip by hand.
+ * used, instead of making the user hunt down a large zip by hand.
+ *
+ * Cross-platform: the artifact layout (vendor dir, executable name, zip name)
+ * is resolved from the current platform/arch, so the same code works on
+ * Windows, Linux and macOS.
  *
  * Behaviour policy ("用户不一定能访问外网"):
  *  - Tries the npmmirror binary mirror first (fast for CN users), then the
@@ -12,33 +16,54 @@
  *    falls back to the in-page pet — never crashes the plugin.
  *  - Concurrency-safe: concurrent calls while a fetch is in flight share one
  *    promise (single in-process lock across the whole host).
- *  - Idempotent: if `vendor/electron-win32-x64/electron.exe` already exists it
+ *  - Idempotent: if the runtime binary already exists in the vendor dir it
  *    resolves immediately without touching the network.
  *
- * Files land exactly where `desktop-window.js`'s `bundledElectron` path points,
- * so a later `resolveBackend()` picks the freshly installed runtime up with no
- * reconfiguration:    <repo>/vendor/electron-win32-x64/electron.exe
+ * Files land exactly where `desktop-window.js`'s bundled-Electron lookup points
+ * (`electronArtifact().exe`), so a later `resolveBackend()` picks the freshly
+ * installed runtime up with no reconfiguration.
  */
 
 import { spawn } from 'node:child_process'
-import { createReadStream, createWriteStream, existsSync, mkdirSync, rmSync } from 'node:fs'
-import { access } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { dirname, resolve } from 'node:path'
+import { createWriteStream, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
-export const VENDOR_DIR = resolve(here, '..', 'vendor', 'electron-win32-x64')
-export const ELECTRON_EXE = resolve(VENDOR_DIR, 'electron.exe')
 
-/** Electron major we target — a stock win32-x64 build in this range works. */
+/** Electron major we target — a stock build in this range works on any platform. */
 export const ELECTRON_VERSION = '33.0.0'
 
-/** Download candidates, best first. Each is the full zip URL (win32-x64). */
-export function downloadMirrors(version = ELECTRON_VERSION) {
+/**
+ * Resolve the Electron artifact layout for a platform/arch. `platform` uses
+ * node's tokens ('win32' | 'linux' | 'darwin'), which match Electron's release
+ * zip naming. `binary` is the executable name (electron.exe on Windows,
+ * electron elsewhere). `vendorDir`/`exe` point where the runtime is installed.
+ */
+export function electronArtifact({ platform = process.platform, arch = process.arch } = {}) {
+  const binary = platform === 'win32' ? 'electron.exe' : 'electron'
+  const dir = `electron-${platform}-${arch}`
+  return {
+    platform,
+    arch,
+    binary,
+    zipName: `electron-v${ELECTRON_VERSION}-${platform}-${arch}.zip`,
+    vendorDir: resolve(here, '..', 'vendor', dir),
+    exe: resolve(here, '..', 'vendor', dir, binary),
+  }
+}
+
+export const VENDOR_DIR = electronArtifact().vendorDir
+export const ELECTRON_EXE = electronArtifact().exe
+
+/**
+ * Download candidates, best first. Each is the full zip URL for the given
+ * platform/arch (defaults to the current one).
+ */
+export function downloadMirrors(version = ELECTRON_VERSION, platform = process.platform, arch = process.arch) {
   // npmmirror hosts the exact same release artifacts as GitHub releases and is
   // much faster / reliable from mainland China. Forward slashes only.
-  const name = `electron-v${version}-win32-x64.zip`
+  const name = `electron-v${version}-${platform}-${arch}.zip`
   return [
     `https://registry.npmmirror.com/-/binary/electron/v${version}/${name}`,
     `https://github.com/electron/electron/releases/download/v${version}/${name}`,
@@ -49,24 +74,26 @@ export function downloadMirrors(version = ELECTRON_VERSION) {
 let inflight = null
 
 /**
- * Ensure the bundled Electron runtime exists, downloading it on demand.
+ * Ensure the Electron runtime exists, downloading it on demand.
  *
  * @param {object} [options]
  * @param {string[]} [options.mirrors]   zip URLs to try, in order.
- * @param {string}  [options.vendorDir]  target directory for the runtime (defaults to <repo>/vendor/electron-win32-x64).
+ * @param {string}  [options.vendorDir]  target directory for the runtime (defaults to the platform vendor dir).
+ * @param {string}  [options.binary]     executable name to place / look for (defaults to the platform binary).
  * @param {(m: string) => void} [options.onProgress]  human-readable progress callback.
  * @param {(cmd: string, args: string[], opts: object) => import('node:child_process').ChildProcess} [options.spawnImpl] injectable spawn (for tests).
- * @returns {Promise<string>}  absolute path to electron.exe on success.
+ * @returns {Promise<string>}  absolute path to the Electron binary on success.
  * @throws  when every mirror fails and no runtime can be placed.
  */
 export async function ensureElectronRuntime({
   mirrors = downloadMirrors(),
   vendorDir = VENDOR_DIR,
+  binary = electronArtifact().binary,
   onProgress,
   spawnImpl = spawn,
   fetchImpl = fetch,
 } = {}) {
-  const electronExe = resolve(vendorDir, 'electron.exe')
+  const electronExe = resolve(vendorDir, binary)
   if (existsSync(electronExe)) return electronExe
   // Serialise concurrent requests across the whole host process.
   if (inflight) return inflight
@@ -94,10 +121,11 @@ export async function ensureElectronRuntime({
       }
       onProgress?.('正在解压 Electron…')
       await unzip(zip, work, spawnImpl)
+      const distDir = findDistDir(work, binary)
       mkdirSync(vendorDir, { recursive: true })
-      await moveContents(work, vendorDir)
+      await moveContents(distDir, vendorDir)
       if (!existsSync(electronExe)) {
-        throw new Error(`解压后未找到 electron.exe（${electronExe}）`)
+        throw new Error(`解压后未找到 ${binary}（${electronExe}）`)
       }
       onProgress?.('Electron 已就绪')
       return electronExe
@@ -144,16 +172,63 @@ async function downloadFile(url, dest, onProgress, fetchImpl = fetch) {
   if (received === 0) throw new Error('下载内容为空')
 }
 
-/** Extract a zip via the platform unzip. On win32 use bsdtar (ships with Windows). */
+/**
+ * Locate the Electron distribution dir inside `work`: either `work` itself
+ * (zip contents at the root) or the single top-level dir the zip contains.
+ * The Electron release zips are not consistent about the top-level dir, so
+ * handle both.
+ */
+function findDistDir(work, binary) {
+  if (existsSync(join(work, binary))) return work
+  const subdirs = readdirSync(work, { withFileTypes: true }).filter((e) => e.isDirectory())
+  for (const sub of subdirs) {
+    if (existsSync(join(work, sub.name, binary))) return join(work, sub.name)
+  }
+  if (subdirs.length === 1) return join(work, subdirs[0].name)
+  throw new Error(`未在解压目录找到 ${binary}：${work}`)
+}
+
+/**
+ * Extract a zip using whichever platform tool is available. On Windows the
+ * built-in bsdtar (tar.exe) handles zip; on Linux/macOS prefer `unzip`, then
+ * bsdtar, then tar. Tries candidates in order and succeeds on the first that
+ * runs cleanly.
+ */
 async function unzip(zip, dest, spawnImpl) {
   mkdirSync(dest, { recursive: true })
-  await runProgram(spawnImpl, 'tar.exe', ['-xf', zip, '-C', dest, '--strip-components=0'], dest)
+  const isWin = process.platform === 'win32'
+  const attempts = isWin
+    ? [
+        ['tar.exe', ['-xf', zip, '-C', dest, '--strip-components=0']],
+        ['unzip', ['-o', zip, '-d', dest]],
+      ]
+    : [
+        ['unzip', ['-o', zip, '-d', dest]],
+        ['bsdtar', ['-xf', zip, '-C', dest]],
+        ['tar', ['-xf', zip, '-C', dest]],
+      ]
+  let lastError = null
+  for (const [cmd, args] of attempts) {
+    try {
+      await runProgram(spawnImpl, cmd, args, dest)
+      return
+    } catch (error) {
+      lastError = error
+      // Clear any partial extraction before trying the next tool.
+      try {
+        for (const entry of readdirSync(dest)) {
+          rmSync(join(dest, entry), { recursive: true, force: true })
+        }
+      } catch { /* ignore */ }
+    }
+  }
+  throw lastError
 }
 
 /** Recursively move directory contents up into `target` (works across drives). */
 async function moveContents(src, target) {
   const { readdir, copyFile, mkdir } = await import('node:fs/promises')
-  const { join, relative } = await import('node:path')
+  const { join } = await import('node:path')
   await mkdir(target, { recursive: true })
   const entries = await readdir(src, { withFileTypes: true })
   for (const entry of entries) {

--- a/src/pet-window.cjs
+++ b/src/pet-window.cjs
@@ -43,6 +43,8 @@ const PET_CONTENT_H = 520
 // 这正是高缩放屏上桌宠物理尺寸减半的根因。因此改读注册表的 AppliedDPI
 // （REG_DWORD，十六进制如 0xc0=192），它不受 force-dsf 开关影响。
 function readSystemScaleFactor() {
+  // 注册表是 Windows 专属；其它平台直接回退，由调用方用 screen API 兜底。
+  if (process.platform !== 'win32') return null
   try {
     const out = execFileSync(
       'reg.exe',

--- a/src/self-update.js
+++ b/src/self-update.js
@@ -351,8 +351,9 @@ export async function checkHandler(req, res) {
 
 // ---- 注入点（宿主注册路由时设置，测试可覆盖）----
 // - stopDesktopWindow：更新前停掉桌面宠物窗并等待其进程退出。桌宠窗的
-//   electron.exe 就住在插件包目录里（vendor/electron-win32-x64），进程不退出时
-//   Windows 会锁住文件——pnpm/git 替换包内容直接 EPERM。未注入（单测/无桌面窗）则跳过。
+//   Electron 运行时就住在插件包目录里（vendor/electron-<platform>-<arch>，
+//   由 electronArtifact 按平台解析）；Windows 上进程不退出会锁住文件——pnpm/git
+//   替换包内容直接 EPERM。未注入（单测/无桌面窗）则跳过。
 // - run / resolveInstall：测试注入假实现用。
 const hooks = {
   stopDesktopWindow: null,

--- a/test/electron-fetch.test.js
+++ b/test/electron-fetch.test.js
@@ -3,6 +3,8 @@
  * idempotency, full download→unzip→place flow, and all-mirrors-fail fallback).
  *
  * These tests never touch the network: fetchImpl / spawnImpl are injected.
+ * They are platform-aware: the expected artifact name / binary name come from
+ * the current platform/arch via electronArtifact().
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
@@ -10,7 +12,10 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { EventEmitter } from 'node:events'
-import { downloadMirrors, ensureElectronRuntime } from '../src/electron-fetch.mjs'
+import { downloadMirrors, ensureElectronRuntime, electronArtifact } from '../src/electron-fetch.mjs'
+
+/** The platform-specific executable name (electron.exe on Windows, electron elsewhere). */
+const BIN = electronArtifact().binary
 
 /** Minimal web ReadableStream carrying one chunk of payload. */
 function streamOf(chunk) {
@@ -36,7 +41,7 @@ function fakeFetch(ok) {
   }
 }
 
-/** Fake `tar -xf zip -C dest`: writes a fake electron.exe into dest. */
+/** Fake zip extractor: writes a fake Electron binary into dest. */
 function fakeSpawn() {
   return (command, args) => {
     const child = new EventEmitter()
@@ -44,11 +49,12 @@ function fakeSpawn() {
     child.killed = false
     child.kill = () => { child.killed = true }
     setImmediate(() => {
-      // args = ['-xf', zip, '-C', work]
-      const work = args[args.indexOf('-C') + 1]
-      mkdirSync(work, { recursive: true })
-      writeFileSync(join(work, 'electron.exe'), 'FAKE_ELECTRON')
-      writeFileSync(join(work, 'LISEZ-moi.txt'), 'fake')
+      // args end with '-C', <dest> (both bsdtar/tar and unzip land files in dest)
+      const idx = args.indexOf('-C')
+      const dest = idx >= 0 ? args[idx + 1] : args[args.indexOf('-d') + 1]
+      mkdirSync(dest, { recursive: true })
+      writeFileSync(join(dest, BIN), 'FAKE_ELECTRON')
+      writeFileSync(join(dest, 'LISEZ-moi.txt'), 'fake')
       child.exitCode = 0
       child.emit('exit', 0)
     })
@@ -58,36 +64,61 @@ function fakeSpawn() {
 
 function tempVendor() {
   const dir = mkdtempSync(join(tmpdir(), 'pet-electron-test-'))
-  const vendor = join(dir, 'vendor', 'electron-win32-x64')
+  const vendor = join(dir, 'vendor', 'electron-test')
   return { dir, vendor }
 }
 
 test('downloadMirrors: npmmirror first, then github, same artifact name', () => {
+  const { platform, arch } = electronArtifact()
+  const name = `electron-v33.0.0-${platform}-${arch}.zip`
   const mirrors = downloadMirrors('33.0.0')
   assert.equal(mirrors.length, 2)
-  assert.match(mirrors[0], /^https:\/\/registry\.npmmirror\.com\/-\/binary\/electron\/v33\.0\.0\/electron-v33\.0\.0-win32-x64\.zip$/)
-  assert.match(mirrors[1], /^https:\/\/github\.com\/electron\/electron\/releases\/download\/v33\.0\.0\/electron-v33\.0\.0-win32-x64\.zip$/)
+  assert.ok(mirrors[0].startsWith('https://registry.npmmirror.com/-/binary/electron/v33.0.0/'))
+  assert.ok(mirrors[0].endsWith(`/${name}`))
+  assert.ok(mirrors[1].startsWith('https://github.com/electron/electron/releases/download/v33.0.0/'))
+  assert.ok(mirrors[1].endsWith(`/${name}`))
+})
+
+test('downloadMirrors: platform-specific names (win32 -> .exe, others -> electron)', () => {
+  const win = downloadMirrors('33.0.0', 'win32', 'x64')
+  assert.ok(win[0].includes('electron-v33.0.0-win32-x64.zip'))
+  const linux = downloadMirrors('33.0.0', 'linux', 'x64')
+  assert.ok(linux[0].includes('electron-v33.0.0-linux-x64.zip'))
+  const linuxArm = downloadMirrors('33.0.0', 'linux', 'arm64')
+  assert.ok(linuxArm[0].includes('electron-v33.0.0-linux-arm64.zip'))
+})
+
+test('electronArtifact: binary name and vendor dir are platform-specific', () => {
+  const win = electronArtifact({ platform: 'win32', arch: 'x64' })
+  assert.equal(win.binary, 'electron.exe')
+  assert.ok(win.vendorDir.includes('electron-win32-x64'))
+  assert.equal(win.zipName, 'electron-v33.0.0-win32-x64.zip')
+
+  const linux = electronArtifact({ platform: 'linux', arch: 'x64' })
+  assert.equal(linux.binary, 'electron')
+  assert.ok(linux.vendorDir.includes('electron-linux-x64'))
+  assert.equal(linux.zipName, 'electron-v33.0.0-linux-x64.zip')
 })
 
 test('ensureElectronRuntime is idempotent when the runtime already exists', async () => {
   const { dir, vendor } = tempVendor()
   try {
     mkdirSync(vendor, { recursive: true })
-    writeFileSync(join(vendor, 'electron.exe'), 'EXISTS')
+    writeFileSync(join(vendor, BIN), 'EXISTS')
     let fetchCalls = 0
     const exe = await ensureElectronRuntime({
       vendorDir: vendor,
       fetchImpl: async () => { fetchCalls += 1; throw new Error('must not fetch') },
       spawnImpl: () => { throw new Error('must not spawn') },
     })
-    assert.equal(exe, resolve(vendor, 'electron.exe'))
+    assert.equal(exe, resolve(vendor, BIN))
     assert.equal(fetchCalls, 0)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('ensureElectronRuntime downloads, unzips and places electron.exe', async () => {
+test('ensureElectronRuntime downloads, unzips and places the Electron binary', async () => {
   const { dir, vendor } = tempVendor()
   const progress = []
   try {
@@ -98,8 +129,8 @@ test('ensureElectronRuntime downloads, unzips and places electron.exe', async ()
       fetchImpl: fakeFetch(true),
       spawnImpl: fakeSpawn(),
     })
-    assert.ok(existsSync(exe), 'electron.exe should be placed')
-    assert.equal(exe, resolve(vendor, 'electron.exe'))
+    assert.ok(existsSync(exe), `${BIN} should be placed`)
+    assert.equal(exe, resolve(vendor, BIN))
     assert.match(progress.join(' '), /已就绪/)
   } finally {
     rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## 背景

本 PR 包含两个相互独立的修复(3 个 commit,可分别 cherry-pick):

### 1. Linux 适配(`dca8165`)

`package.json` 中 `"os": ["win32"], "cpu": ["x64"]` 使插件在 Linux / arm64 上被安装门槛直接拒绝;桌面浮窗相关代码也写死了 `vendor/electron-win32-x64/electron.exe`。

页面内桌宠(web client)本身是跨平台的,Linux 用户同样应能安装使用;桌面浮窗模式也应能在 Linux(X11)上工作。

### 2. fnOS/TRIM gateway 前缀路由下贴图 404(`6ccfd21`)

**现象**:通过 NAS webui 的 `/app/<id>/` 前缀路由远程访问 dsh web 时,宠物只剩文字气泡、贴图不显示、拖不动。

**根因**:宿主 gateway 桥接只改写 HTML 静态 `src`/`href`、`fetch`、`EventSource` 与 `<script src>`;客户端**运行时** JS 赋值的 `img.src`(贴纸 `gifUrl`、双击画画 pics、气泡卡 favicon)不被改写,请求落到 NAS 根路径 → 拿到非 GIF 响应 → `img.onerror` 隐藏贴图,气泡又吞掉 pointer 事件 → 拖拽失效。

**修复**:从本 bundle 自己的 `<script>` 加载路径检测 gateway 前缀(回退页面 path;直连无前缀模式返回空串),所有运行时绝对路径经 `withPrefix()` 带上前缀。直连模式行为完全不变。

### 3. 注释清理(`36cf850`)

两处写死 `vendor/electron-win32-x64` 的过期注释改为平台感知表述。

## 主要改动

### Linux 适配

- `package.json`:`os` 增加 `linux`、`cpu` 增加 `arm64`。
- `src/electron-fetch.mjs`:新增 `electronArtifact({platform, arch})`(按平台解析 vendor 目录 / 二进制名 / zip 名 / exe 路径);解压逻辑跨平台(`unzip` / `bsdtar` / `tar`);兼容新版 zip 的根目录结构(`findDistDir`)。
- `src/desktop-window.js`:bundled runtime 路径改经 `electronArtifact` 解析,不再写死 win32。
- `src/pet-window.cjs`:注册表读系统 DPI 仅 Windows 生效,其它平台回退 Electron `screen` API。
- `test/electron-fetch.test.js`:用例平台感知化(Linux 上 win32-bundled 用例 skip)。

### fnOS gateway 前缀修复

- `src/client.core.js`:新增 `RM_GATEWAY_PREFIX` 检测 + `withPrefix()`;`gifUrl`、pics、favicon 全部带前缀。
- `lib/client.js`:bundle 重建。

## 验证

- `pnpm check` 全过;`pnpm test` 179 条(178 过 / 0 败 / 1 skip——win32-bundled 用例在 Linux 上的预期 skip)。
- Linux 运行时冒烟:`electronArtifact()` → `vendor/electron-linux-x64/electron`;镜像源优先 npmmirror;本机无 Electron 时 `backendCandidates` 为空、优雅降级为页面内桌宠。
- 端到端(无头 Chrome 152):直连 `127.0.0.1:3080` 与经 gateway 前缀路由访问,贴图均正常加载渲染(`naturalWidth` 360)、状态气泡与拖拽正常。
- Windows 兼容性:`electronArtifact({platform:'win32',arch:'x64'})` 的 vendor 目录 / 二进制名 / zip 名与旧写死值一致,行为不变。

## 备注

- Linux 桌面浮窗需要 X11;首次启用桌面模式会自动下载 Linux Electron 运行时(约 221MB,npmmirror 优先);未启用时不影响页面内桌宠。
- fnOS 修复对无前缀宿主(直连 / 其他宿主)零影响:直连模式下检测到的前缀为空串。
