### PR TITLE
feat(desktop): 支持 macOS / Linux 桌面悬浮窗

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,16 +133,17 @@ dsh plugin --profile web add dsh-pet-remielle
 - 右键菜单：切换网页模式、锁定、气泡开关、角色大小、画画等。
 - 关闭/切换后自动回到页面内；随 DSH host 退出自动关闭。
 
-**Electron 运行时来源（按顺序探测）**：`DSH_PET_ELECTRON` 环境变量 → `vendor/electron-win32-x64/`（本目录不进 Git）→ 系统已安装的 Electron → 均无则仅页面内展示。
+**Electron 运行时来源（按顺序探测）**：`DSH_PET_ELECTRON` 环境变量 → `vendor/electron-<platform>-<arch>/`（本目录不进 Git，按当前系统自动下载对应平台包）→ 系统已安装的 Electron → 均无则仅页面内展示。
 
-> **首次运行**：若开启桌面悬浮模式但本机找不到 Electron 运行时，会**提示下载并安装**（需你确认，因 Electron 运行时约 200MB）；下载失败则自动回落页面内展示，不会影响其他功能。也可手动把任一 Electron win32-x64 发行包解压到 `vendor/electron-win32-x64/`，或设置 `DSH_PET_ELECTRON` 指向现有 `electron.exe`。
+> **首次运行**：若开启桌面悬浮模式但本机找不到 Electron 运行时，会**提示下载并安装**（需你确认，因 Electron 运行时约 100–220MB，Windows 最大）；下载失败则自动回落页面内展示，不会影响其他功能。也可手动把任一对应平台的 Electron 发行包解压到 `vendor/electron-<platform>-<arch>/`，或设置 `DSH_PET_ELECTRON` 指向现有 electron 可执行文件（Windows：`electron.exe`；macOS：`Electron.app/Contents/MacOS/Electron`；Linux：`electron`）。
 
 ### 平台能力
 
 | 平台 | 桌面悬浮窗 | 页面内桌宠 |
 |---|---|---|
-| Windows x64（Fairy 桌面版 / 纯 DSH） | ✓（Electron 透明置顶窗口） | 桌面模式下自动隐藏 |
-| macOS / Linux | ✗ | ✓（自动回落页面内） |
+| Windows x64 | ✓（Electron 透明置顶窗口） | 桌面模式下自动隐藏 |
+| macOS（arm64 / x64） | ✓（自动下载对应 darwin Electron） | 桌面模式下自动隐藏 |
+| Linux x64 | ✓（自动下载对应 linux Electron） | 桌面模式下自动隐藏 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -52,10 +52,13 @@
   },
   "license": "MIT",
   "os": [
-    "win32"
+    "win32",
+    "darwin",
+    "linux"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ],
   "author": "dsh-pet-remielle contributors",
   "keywords": [

--- a/src/desktop-window.js
+++ b/src/desktop-window.js
@@ -24,9 +24,9 @@ import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { runtimeTarget, electronBinaryIn } from './electron-fetch.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
-const bundledElectron = resolve(here, '..', 'vendor', 'electron-win32-x64', 'electron.exe')
 
 /**
  * Walk up from `startDir` looking for a directory containing the given
@@ -79,9 +79,8 @@ function getNpmGlobalPrefix() {
  * injectable for tests.
  * @returns `[{ kind: 'electron', command, args }]`.
  */
-export function backendCandidates({ platform = process.platform, cwd = process.cwd() } = {}) {
+export function backendCandidates({ platform = process.platform, cwd = process.cwd(), arch = process.arch } = {}) {
   const candidates = []
-  const electron = platform === 'win32' ? 'electron.exe' : 'electron'
   const args = [resolve(here, 'pet-window.cjs')]
 
   // --- 1. DSH_PET_ELECTRON env var override (highest priority) ---
@@ -89,15 +88,16 @@ export function backendCandidates({ platform = process.platform, cwd = process.c
     candidates.push({ kind: 'electron', command: process.env.DSH_PET_ELECTRON, args })
   }
 
-  // --- 2. Bundled vendor runtime (shipped with the plugin) ---
-  if (platform === 'win32' && existsSync(bundledElectron)) {
-    candidates.push({ kind: 'electron', command: bundledElectron, args })
+  // --- 2. Bundled vendor runtime (ships with the plugin) ---
+  const bundled = electronBinaryIn(resolve(here, '..', 'vendor', runtimeTarget(platform, arch).folder), platform, arch)
+  if (existsSync(bundled)) {
+    candidates.push({ kind: 'electron', command: bundled, args })
   }
 
   // --- 3. npm global install — user ran `npm install -g electron` somewhere ---
   const npmPrefix = getNpmGlobalPrefix()
   if (npmPrefix) {
-    const globalElectron = resolve(npmPrefix, 'node_modules', 'electron', 'dist', electron)
+    const globalElectron = electronBinaryIn(resolve(npmPrefix, 'node_modules', 'electron', 'dist'), platform, arch)
     if (existsSync(globalElectron)) {
       candidates.push({ kind: 'electron', command: globalElectron, args })
     }
@@ -111,7 +111,7 @@ export function backendCandidates({ platform = process.platform, cwd = process.c
       resolve(dshRoot, 'node_modules', 'electron', 'dist'),
       resolve(dshRoot, 'desktop', 'node_modules', 'electron', 'dist'),
     ]) {
-      const command = resolve(base, electron)
+      const command = electronBinaryIn(base, platform, arch)
       if (existsSync(command)) {
         candidates.push({ kind: 'electron', command, args })
         break
@@ -124,7 +124,7 @@ export function backendCandidates({ platform = process.platform, cwd = process.c
     resolve(cwd, 'desktop/node_modules/electron/dist'),
     resolve(cwd, 'node_modules/electron/dist'),
   ]) {
-    const command = resolve(base, electron)
+    const command = electronBinaryIn(base, platform, arch)
     if (existsSync(command)) {
       candidates.push({ kind: 'electron', command, args })
       break

--- a/src/electron-fetch.mjs
+++ b/src/electron-fetch.mjs
@@ -12,12 +12,12 @@
  *    falls back to the in-page pet — never crashes the plugin.
  *  - Concurrency-safe: concurrent calls while a fetch is in flight share one
  *    promise (single in-process lock across the whole host).
- *  - Idempotent: if `vendor/electron-win32-x64/electron.exe` already exists it
+ *  - Idempotent: if the runtime binary for the current platform already exists it
  *    resolves immediately without touching the network.
  *
  * Files land exactly where `desktop-window.js`'s `bundledElectron` path points,
  * so a later `resolveBackend()` picks the freshly installed runtime up with no
- * reconfiguration:    <repo>/vendor/electron-win32-x64/electron.exe
+ * reconfiguration:    <repo>/vendor/electron-<platform>-<arch>/<binary>
  */
 
 import { spawn } from 'node:child_process'
@@ -28,17 +28,48 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
-export const VENDOR_DIR = resolve(here, '..', 'vendor', 'electron-win32-x64')
-export const ELECTRON_EXE = resolve(VENDOR_DIR, 'electron.exe')
 
-/** Electron major we target — a stock win32-x64 build in this range works. */
+/**
+ * Map an OS/arch to the Electron release artifact triple plus the on-disk
+ * folder name and the path (relative to that folder) of the launchable
+ * Electron binary.
+ *
+ * Windows keeps the exact original layout (`electron-win32-x64/electron.exe`)
+ * so Windows behaviour is byte-for-byte unchanged. macOS uses the `.app`
+ * bundle binary; Linux uses the bare `electron` binary.
+ *
+ * @param {string} [platform]  process.platform (injectable for tests).
+ * @param {string} [arch]      process.arch (injectable for tests).
+ */
+export function runtimeTarget(platform = process.platform, arch = process.arch) {
+  if (platform === 'win32') {
+    return { tag: 'win32-x64', folder: 'electron-win32-x64', sub: ['electron.exe'] }
+  }
+  if (platform === 'darwin') {
+    const a = arch === 'arm64' ? 'arm64' : 'x64'
+    return { tag: `darwin-${a}`, folder: `electron-darwin-${a}`, sub: ['Electron.app', 'Contents', 'MacOS', 'Electron'] }
+  }
+  if (platform === 'linux') {
+    return { tag: 'linux-x64', folder: 'electron-linux-x64', sub: ['electron'] }
+  }
+  return { tag: `${platform}-${arch}`, folder: `electron-${platform}-${arch}`, sub: ['electron'] }
+}
+
+/** Absolute path to the launchable Electron binary inside a dist/vendor root. */
+export function electronBinaryIn(dir, platform = process.platform, arch = process.arch) {
+  return resolve(dir, ...runtimeTarget(platform, arch).sub)
+}
+
+export const VENDOR_DIR = resolve(here, '..', 'vendor', runtimeTarget().folder)
+export const ELECTRON_EXE = electronBinaryIn(VENDOR_DIR)
+
+/** Electron major we target — a stock build in this range works on any OS. */
 export const ELECTRON_VERSION = '33.0.0'
 
-/** Download candidates, best first. Each is the full zip URL (win32-x64). */
-export function downloadMirrors(version = ELECTRON_VERSION) {
-  // npmmirror hosts the exact same release artifacts as GitHub releases and is
-  // much faster / reliable from mainland China. Forward slashes only.
-  const name = `electron-v${version}-win32-x64.zip`
+/** Download candidates, best first. Each is the full zip URL for the current
+ *  platform/arch (npmmirror first: fast in mainland China, then GitHub). */
+export function downloadMirrors(version = ELECTRON_VERSION, platform = process.platform, arch = process.arch) {
+  const name = `electron-v${version}-${runtimeTarget(platform, arch).tag}.zip`
   return [
     `https://registry.npmmirror.com/-/binary/electron/v${version}/${name}`,
     `https://github.com/electron/electron/releases/download/v${version}/${name}`,
@@ -65,8 +96,10 @@ export async function ensureElectronRuntime({
   onProgress,
   spawnImpl = spawn,
   fetchImpl = fetch,
+  platform = process.platform,
+  arch = process.arch,
 } = {}) {
-  const electronExe = resolve(vendorDir, 'electron.exe')
+  const electronExe = electronBinaryIn(vendorDir, platform, arch)
   if (existsSync(electronExe)) return electronExe
   // Serialise concurrent requests across the whole host process.
   if (inflight) return inflight
@@ -93,11 +126,16 @@ export async function ensureElectronRuntime({
         }
       }
       onProgress?.('正在解压 Electron…')
-      await unzip(zip, work, spawnImpl)
+      // 直接解压进 vendorDir，而不是先解到临时目录再逐文件 moveContents：
+      // macOS 的 Electron.app bundle 内含符号链接/特殊文件，copyFile 会因
+      // ENOTSUP 失败；bsdtar/tar 解压会原样保留它们。vendorDir 是全新目录
+      //（下载前已 rm），解压后直接校验可执行文件即可。
+      rmSync(vendorDir, { recursive: true, force: true })
       mkdirSync(vendorDir, { recursive: true })
-      await moveContents(work, vendorDir)
+      await unzip(zip, vendorDir, spawnImpl, platform)
       if (!existsSync(electronExe)) {
-        throw new Error(`解压后未找到 electron.exe（${electronExe}）`)
+        const target = runtimeTarget(platform, arch)
+        throw new Error(`解压后未找到 Electron 可执行文件（${electronExe}）——期望安装包内含 ${target.tag} 的 ${target.sub.join('/')}`)
       }
       onProgress?.('Electron 已就绪')
       return electronExe
@@ -144,29 +182,12 @@ async function downloadFile(url, dest, onProgress, fetchImpl = fetch) {
   if (received === 0) throw new Error('下载内容为空')
 }
 
-/** Extract a zip via the platform unzip. On win32 use bsdtar (ships with Windows). */
-async function unzip(zip, dest, spawnImpl) {
+/** Extract a zip via the platform unzip. On win32 use bsdtar (ships with
+ *  Windows); on macOS/Linux use the standard `tar` (bsdtar on macOS). */
+async function unzip(zip, dest, spawnImpl, platform = process.platform) {
   mkdirSync(dest, { recursive: true })
-  await runProgram(spawnImpl, 'tar.exe', ['-xf', zip, '-C', dest, '--strip-components=0'], dest)
-}
-
-/** Recursively move directory contents up into `target` (works across drives). */
-async function moveContents(src, target) {
-  const { readdir, copyFile, mkdir } = await import('node:fs/promises')
-  const { join, relative } = await import('node:path')
-  await mkdir(target, { recursive: true })
-  const entries = await readdir(src, { withFileTypes: true })
-  for (const entry of entries) {
-    const from = join(src, entry.name)
-    const to = join(target, entry.name)
-    if (entry.isDirectory()) {
-      // Recurse and then remove the emptied source dir.
-      await moveContents(from, to)
-      try { rmSync(from, { recursive: true, force: true }) } catch { /* ignore */ }
-    } else {
-      await copyFile(from, to)
-    }
-  }
+  const tar = platform === 'win32' ? 'tar.exe' : 'tar'
+  await runProgram(spawnImpl, tar, ['-xf', zip, '-C', dest, '--strip-components=0'], dest)
 }
 
 /** Run a child program to completion; reject on non-zero exit. */

--- a/src/index.js
+++ b/src/index.js
@@ -933,11 +933,18 @@ function mount(ctx, config = {}, eventCtx = ctx) {
       const origin = `http://127.0.0.1:${port}`
       const desktopUrl = `${origin}${PET_VIEW_ENDPOINT}`
       // DSH 0.1.2-alpha.1 起 Web 壳根路径要带进程 token；旧宿主没有该方法则仍打开 origin。
+      // 容错：authenticatedUrl 在个别宿主/会话态下可能抛错；失败时回落 origin，
+      // 避免 startDesktop 因此抛异常导致桌面窗根本起不来。
       const dshWebUrl = () => {
-        const connection = ctx.connection
-        return typeof connection?.authenticatedUrl === 'function'
-          ? connection.authenticatedUrl(origin)
-          : origin
+        try {
+          const connection = ctx.connection
+          return typeof connection?.authenticatedUrl === 'function'
+            ? connection.authenticatedUrl(origin)
+            : origin
+        } catch (error) {
+          logger.warn?.(`dsh-pet-remielle: dshWebUrl() 失败，回落 origin（${String(error)}）`)
+          return origin
+        }
       }
       const onDesktopExit = () => {
         desktop = undefined
@@ -953,10 +960,22 @@ function mount(ctx, config = {}, eventCtx = ctx) {
         if (!allowFetch && settings.get().desktopMode === false) return
         /** Create a DesktopWindow, attach it, and broadcast state. */
         const spawnWindow = () => {
-          const w = new DesktopWindow({ url: desktopUrl, webUrl: dshWebUrl(), logger, onExit: onDesktopExit })
+          let w
+          try {
+            w = new DesktopWindow({ url: desktopUrl, webUrl: dshWebUrl(), logger, onExit: onDesktopExit })
+          } catch (error) {
+            logger.error?.(`dsh-pet-remielle: 创建桌面窗失败：${String(error)}`)
+            return false
+          }
           if (!w.backend) return false
           desktop = w
-          w.start()
+          try {
+            w.start()
+          } catch (error) {
+            logger.error?.(`dsh-pet-remielle: 启动桌面窗进程失败：${String(error)}`)
+            desktop = undefined
+            return false
+          }
           if (!desktopActive) { desktopActive = true; hub.broadcast() }
           return true
         }

--- a/src/pet-window.cjs
+++ b/src/pet-window.cjs
@@ -18,6 +18,11 @@ const { app, BrowserWindow, ipcMain, screen, shell } = require('electron')
 const path = require('node:path')
 const { execFileSync } = require('node:child_process')
 
+// Electron 在 macOS 上为透明窗（transparent:true）触发 'textured' 弃用警告。
+// 它无害（窗口正常工作），但会被子进程 stderr 转发进宿主终端造成噪音。
+// 关闭 DeprecationWarning 打印，保持终端干净；不影响任何功能。
+process.noDeprecation = true
+
 // Isolate the pet window's userData: sharing the default %APPDATA%/Electron
 // with the harness shell locks the disk cache and can serve stale cached
 // responses (the page kept running the old right-click-to-close logic).
@@ -29,7 +34,13 @@ const parentPid = Number(process.env.DSH_PET_PARENT_PID || 0)
 // 该 vendor 运行时在部分 100% 缩放的机器上会把 scaleFactor 误报为 1.1，
 // 导致 DIP↔物理换算有损：窗口随每次定位按 ~1.1 倍膨胀、拖动坐标漂移。
 // 真实屏幕缩放由系统决定；这里强制按 1 处理，使所有边界换算无损。
-app.commandLine.appendSwitch('force-device-scale-factor', '1')
+// macOS 例外：Electron 在 darwin 上自动按 Retina 背板尺寸渲染，强制 dsf=1
+// 让内容以 1x 物理像素绘制、窗口尺寸按点计算产生错位，故仅在非
+// macOS 上强制（macOS 走原生逻辑点，见下方 scaleRoot 的 darwin 分支）。
+const isMac = process.platform === 'darwin'
+if (!isMac) {
+  app.commandLine.appendSwitch('force-device-scale-factor', '1')
+}
 
 // 拖动定位时同时锁定的内容尺寸（与 BrowserWindow 创建参数一致），
 // 防止任何 bounds 往返误差累积改变窗口大小。
@@ -78,7 +89,10 @@ app.whenReady().then(() => {
   // 真实缩放渲染」的做法：非整数缩放下 DIP↔物理往返有截断误差，拖拽闭环会
   // 复发持续漂移（见 drag-move 去重注释）；保持 dsf=1 的无损换算再补偿。
   // 局限：多显示器缩放不同时以主屏为准，不做跨屏动态切换。
-  const scaleRoot = Math.min(2, Math.max(0.5, readSystemScaleFactor() || screen.getPrimaryDisplay().scaleFactor || 1))
+  // macOS：Electron 以逻辑点渲染，且自动按 Retina 背板倍数缩放；
+  // 无需强制 1x，也不用缩放补偿，window/内容都按 400×520 逻辑点即可。
+  // 其它平台沿用 readSystemScaleFactor（Windows）→ screen.scaleFactor 回退。
+  const scaleRoot = isMac ? 1 : Math.min(2, Math.max(0.5, readSystemScaleFactor() || screen.getPrimaryDisplay().scaleFactor || 1))
   const uiZoom = scaleRoot
   const petW = Math.round(PET_CONTENT_W * uiZoom)
   const petH = Math.round(PET_CONTENT_H * uiZoom)

--- a/test/electron-fetch.test.js
+++ b/test/electron-fetch.test.js
@@ -8,9 +8,9 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
 import { EventEmitter } from 'node:events'
-import { downloadMirrors, ensureElectronRuntime } from '../src/electron-fetch.mjs'
+import { downloadMirrors, ensureElectronRuntime, runtimeTarget, electronBinaryIn } from '../src/electron-fetch.mjs'
 
 /** Minimal web ReadableStream carrying one chunk of payload. */
 function streamOf(chunk) {
@@ -36,8 +36,8 @@ function fakeFetch(ok) {
   }
 }
 
-/** Fake `tar -xf zip -C dest`: writes a fake electron.exe into dest. */
-function fakeSpawn() {
+/** Fake `tar -xf zip -C dest`: writes a fake electron.exe into dest (win32). */
+function fakeSpawn(platform = 'win32') {
   return (command, args) => {
     const child = new EventEmitter()
     child.exitCode = null
@@ -47,8 +47,15 @@ function fakeSpawn() {
       // args = ['-xf', zip, '-C', work]
       const work = args[args.indexOf('-C') + 1]
       mkdirSync(work, { recursive: true })
-      writeFileSync(join(work, 'electron.exe'), 'FAKE_ELECTRON')
-      writeFileSync(join(work, 'LISEZ-moi.txt'), 'fake')
+      if (platform === 'darwin') {
+        const bin = join(work, 'Electron.app', 'Contents', 'MacOS', 'Electron')
+        mkdirSync(dirname(bin), { recursive: true })
+        writeFileSync(bin, 'FAKE_ELECTRON')
+        writeFileSync(join(work, 'LICENSE'), 'fake')
+      } else {
+        writeFileSync(join(work, 'electron.exe'), 'FAKE_ELECTRON')
+        writeFileSync(join(work, 'LISEZ-moi.txt'), 'fake')
+      }
       child.exitCode = 0
       child.emit('exit', 0)
     })
@@ -63,10 +70,24 @@ function tempVendor() {
 }
 
 test('downloadMirrors: npmmirror first, then github, same artifact name', () => {
-  const mirrors = downloadMirrors('33.0.0')
+  const mirrors = downloadMirrors('33.0.0', 'win32', 'x64')
   assert.equal(mirrors.length, 2)
   assert.match(mirrors[0], /^https:\/\/registry\.npmmirror\.com\/-\/binary\/electron\/v33\.0\.0\/electron-v33\.0\.0-win32-x64\.zip$/)
   assert.match(mirrors[1], /^https:\/\/github\.com\/electron\/electron\/releases\/download\/v33\.0\.0\/electron-v33\.0\.0-win32-x64\.zip$/)
+})
+
+test('downloadMirrors targets darwin-arm64 on Apple Silicon', () => {
+  const [m0, m1] = downloadMirrors('33.0.0', 'darwin', 'arm64')
+  assert.match(m0, /electron-v33\.0\.0-darwin-arm64\.zip$/)
+  assert.match(m1, /electron-v33\.0\.0-darwin-arm64\.zip$/)
+})
+
+test('runtimeTarget/electronBinaryIn map the launchable binary per platform', () => {
+  assert.deepEqual(runtimeTarget('win32', 'x64').sub, ['electron.exe'])
+  assert.equal(electronBinaryIn('/v', 'win32', 'x64'), resolve('/v', 'electron.exe'))
+  assert.deepEqual(runtimeTarget('darwin', 'arm64').sub, ['Electron.app', 'Contents', 'MacOS', 'Electron'])
+  assert.equal(electronBinaryIn('/v', 'darwin', 'arm64'), resolve('/v', 'Electron.app', 'Contents', 'MacOS', 'Electron'))
+  assert.deepEqual(runtimeTarget('darwin', 'x64').sub, ['Electron.app', 'Contents', 'MacOS', 'Electron'])
 })
 
 test('ensureElectronRuntime is idempotent when the runtime already exists', async () => {
@@ -77,6 +98,8 @@ test('ensureElectronRuntime is idempotent when the runtime already exists', asyn
     let fetchCalls = 0
     const exe = await ensureElectronRuntime({
       vendorDir: vendor,
+      platform: 'win32',
+      arch: 'x64',
       fetchImpl: async () => { fetchCalls += 1; throw new Error('must not fetch') },
       spawnImpl: () => { throw new Error('must not spawn') },
     })
@@ -94,13 +117,34 @@ test('ensureElectronRuntime downloads, unzips and places electron.exe', async ()
     const exe = await ensureElectronRuntime({
       mirrors: ['https://mirror.test/electron.zip'],
       vendorDir: vendor,
+      platform: 'win32',
+      arch: 'x64',
       onProgress: (m) => progress.push(m),
       fetchImpl: fakeFetch(true),
-      spawnImpl: fakeSpawn(),
+      spawnImpl: fakeSpawn('win32'),
     })
     assert.ok(existsSync(exe), 'electron.exe should be placed')
     assert.equal(exe, resolve(vendor, 'electron.exe'))
     assert.match(progress.join(' '), /已就绪/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('ensureElectronRuntime places the Electron.app bundle binary on macOS', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pet-electron-test-'))
+  const vendor = join(dir, 'vendor', 'electron-darwin-arm64')
+  try {
+    const exe = await ensureElectronRuntime({
+      mirrors: ['https://mirror.test/electron.zip'],
+      vendorDir: vendor,
+      platform: 'darwin',
+      arch: 'arm64',
+      fetchImpl: fakeFetch(true),
+      spawnImpl: fakeSpawn('darwin'),
+    })
+    assert.equal(exe, resolve(vendor, 'Electron.app', 'Contents', 'MacOS', 'Electron'))
+    assert.ok(existsSync(exe), 'macOS Electron binary should be placed')
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -113,6 +157,8 @@ test('ensureElectronRuntime rejects when every mirror fails', async () => {
       ensureElectronRuntime({
         mirrors: ['https://a.test/x.zip', 'https://b.test/y.zip'],
         vendorDir: vendor,
+        platform: 'win32',
+        arch: 'x64',
         fetchImpl: fakeFetch(false),
         spawnImpl: () => { throw new Error('must not spawn') },
       }),
@@ -130,12 +176,14 @@ test('ensureElectronRuntime falls through to the second mirror after the first f
     await ensureElectronRuntime({
       mirrors: ['https://mirror-1.test/a.zip', 'https://mirror-2.test/b.zip'],
       vendorDir: vendor,
+      platform: 'win32',
+      arch: 'x64',
       fetchImpl: async (url) => {
         tried.push(url)
         if (url.includes('mirror-1')) return { ok: false, status: 503, statusText: 'unavailable', headers: { get: () => null }, body: null }
         return { ok: true, status: 200, statusText: 'OK', headers: { get: (k) => (k === 'content-length' ? '5' : null) }, body: streamOf('hello') }
       },
-      spawnImpl: fakeSpawn(),
+      spawnImpl: fakeSpawn('win32'),
     })
     assert.equal(tried.length, 2, 'should have tried both mirrors')
   } finally {


### PR DESCRIPTION
插件此前仅支持 Windows x64：Electron 运行时硬编码下载 win32-x64 包、 用 Windows 的 tar.exe 解压、后端也只定位 electron.exe，导致在 macOS 上 开启「桌面悬浮模式」后既拉不起悬浮窗、又隐藏了页面桌宠。

本次改动让桌面模式跨平台生效：
- electron-fetch: 新增 runtimeTarget()/electronBinaryIn()，按进程 平台/架构选择对应发行包（macOS 下载 darwin-arm64/x64，Windows 保持 electron-win32-x64 不变，Linux 走 electron）；解压用系统 tar（macOS/ Linux）而非 tar.exe；改为直接把 zip 解压进 vendor/，避免逐文件 copyFile 在 Electron.app 符号链接上抛 ENOTSUP。
- desktop-window: 候选后端按平台定位可执行文件（macOS 指向 Electron.app/Contents/MacOS/Electron）。
- pet-window: macOS 走原生逻辑点渲染（不强制 device-scale-factor=1， 不做 Windows 注册表 DPI 补偿）。
- package.json: os/cpu 放开为 win32/darwin/linux + x64/arm64。
- 测试: 既有 win32 用例显式注入平台以保留语义，并新增 darwin-arm64 用例。

已本地验证：真机下载 darwin-arm64 Electron 成功，DesktopWindow 能 解析到 mac 二进制并正常拉起悬浮窗；npm test（171 pass / 0 fail）。
<img width="1680" height="1050" alt="Screenshot 2026-09-02 at 10 41 07 am" src="https://github.com/user-attachments/assets/a7c7a7f8-b9d3-4d00-a39b-78ee8ac06cb3" />
Linux只是顺手加了，但是没有测试，如果存在问题我可以另外修改