### PR TITLE
fix: require authenticated DSH connection for desktop web launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Linux 适配：插件不再仅限 Windows（`os` 增加 `linux`、`cpu` 增加 `arm64`）。桌面浮窗运行时改为按平台/架构解析（vendor 目录、二进制名、zip 名、跨平台解压），Electron 缺失时仍回落页面内宠物；桌面窗 DPI 注册表读取仅在 Windows 生效，其它平台回退 Electron screen API。
 
 ### Fixes
-- 桌面离线打开 DSH 网页：有 `ctx.connection.authenticatedUrl` 时带上 0.1.2 进程 token，旧宿主仍打开 origin。
+- 桌面离线打开 DSH 网页：通过 `ctx.connection.authenticatedUrl` 带上 0.1.2 进程 token；桌面模式要求 DSH `>= 0.1.2-alpha.1`。
 - fnOS/TRIM gateway 前缀路由（`/app/<id>/`）支持：dsh web 挂载在前缀下时，宿主桥接只改写 HTML 静态 `src`/`fetch`/`EventSource`/`<script src>`，运行时 JS 赋值的 `img.src`（贴纸、双击画画 pics、气泡卡 favicon）不被改写，请求落到 NAS 根路径 404 → 宠物贴图消失（只剩文字气泡）、气泡吞掉 pointer 事件导致拖不动。现从本 bundle 的 `<script>` 加载路径检测前缀（回退页面 path），所有运行时绝对路径带前缀；直连模式（无前缀）行为不变。
 
 ## [0.3.6] — 2026-08-22

--- a/README-EN.md
+++ b/README-EN.md
@@ -12,7 +12,7 @@ A multi-pet web desktop pet **driven by real DSH session events** — it tracks 
 - Built-in version check + one-click incremental update
 - Settings panel: pet management (tabbed) + plugin config card
 
-> Compatible with DeepSeek Harness (and its forks) web profile; desktop mode is off by default and can be enabled anytime.
+> Compatible with DeepSeek Harness (and its forks) web profile; desktop mode is off by default and can be enabled anytime. Desktop mode requires DSH `>= 0.1.2-alpha.1` to provide an authenticated root URL with a launch token.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - 一键版本检查 + 增量更新
 - 设置面板：宠物管理（多标签页）、插件配置卡片
 
-> 兼容 DeepSeek Harness（含其分支）的 web profile；桌面悬浮模式默认关闭，可按需开启。
+> 兼容 DeepSeek Harness（含其分支）的 web profile；桌面悬浮模式默认关闭，可按需开启。桌面模式要求 DSH `>= 0.1.2-alpha.1`，以提供带 token 的认证根 URL。
 
 ---
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -133,6 +133,72 @@ const RM_PLUGIN_VERSION = "0.3.6"
     return '点击去看 ' + parts.join(' · ') + ' 哦~'
   }
 
+  // 让背板的点击目标和提示文字成对更新，并在候选目标稳定后再提交。
+  function createBackboardStabilizer(commit, delay, schedule, cancel) {
+    var currentTarget = ''
+    var currentTip = ''
+    var pendingTarget = ''
+    var pendingTip = ''
+    var timer = 0
+    var commitFn = typeof commit === 'function' ? commit : function () {}
+    var scheduleFn = typeof schedule === 'function' ? schedule : function (fn, ms) { return setTimeout(fn, ms) }
+    var cancelFn = typeof cancel === 'function' ? cancel : function (id) { clearTimeout(id) }
+
+    function clearTimer() {
+      if (!timer) return
+      cancelFn(timer)
+      timer = 0
+    }
+
+    function commitNow(target, tip) {
+      clearTimer()
+      currentTarget = target
+      currentTip = tip
+      pendingTarget = ''
+      pendingTip = ''
+      commitFn(target, tip)
+    }
+
+    function update(target, tip) {
+      target = String(target || '')
+      tip = String(tip || '')
+      if (!target) {
+        commitNow('', '')
+        return
+      }
+      if (target === currentTarget && tip === currentTip) {
+        pendingTarget = ''
+        pendingTip = ''
+        clearTimer()
+        return
+      }
+      if (!currentTarget) {
+        commitNow(target, tip)
+        return
+      }
+      pendingTarget = target
+      pendingTip = tip
+      clearTimer()
+      timer = scheduleFn(function () {
+        timer = 0
+        commitNow(pendingTarget, pendingTip)
+      }, delay)
+    }
+
+    return {
+      update: update,
+      target: function () { return currentTarget },
+      tip: function () { return currentTip },
+      clear: clearTimer,
+    }
+  }
+
+  function openIdleDshPage(bridge) {
+    if (!bridge || typeof bridge.openDshPage !== 'function') return false
+    bridge.openDshPage()
+    return true
+  }
+
   function applyDotTip(dot, page, anchor, show) {
     if (!dot || !dot.dataset) return
     dot.dataset.rm2Tip = dotTipText(page)
@@ -213,6 +279,8 @@ const RM_PLUGIN_VERSION = "0.3.6"
   global.__rm2PetTip = {
     dotTipText: dotTipText,
     backboardTipText: backboardTipText,
+    createBackboardStabilizer: createBackboardStabilizer,
+    openIdleDshPage: openIdleDshPage,
     applyDotTip: applyDotTip,
     onDotLeave: onDotLeave,
     layoutPetTip: layoutPetTip,
@@ -300,23 +368,23 @@ function withPrefix(p) { return RM_GATEWAY_PREFIX + p }
 var CSS = [
   // Right-click menu — pink palette, matching the status bubble on both the
   // in-page pet and the desktop window (hardcoded, not DSW vars).
-  '.rm2-pet-menu{position:fixed;z-index:2147483000;min-width:200px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);border-radius:10px;box-shadow:0 8px 24px rgba(190,70,110,.22);padding:6px;font-family:system-ui,sans-serif;font-size:13px;color:#8a2f52;display:none;user-select:none;}',
-  '.rm2-pet-menu-item{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:7px 10px;border-radius:7px;cursor:pointer;white-space:nowrap;}',
+  '.rm2-pet-menu{position:fixed;z-index:2147483000;min-width:200px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);border-radius:10px;corner-shape:round!important;box-shadow:0 8px 24px rgba(190,70,110,.22);padding:6px;font-family:system-ui,sans-serif;font-size:13px;color:#8a2f52;display:none;user-select:none;}',
+  '.rm2-pet-menu-item{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:7px 10px;border-radius:7px;corner-shape:round!important;cursor:pointer;white-space:nowrap;}',
   '.rm2-pet-menu-item:hover{background:rgba(240,120,160,.14);}',
   '.rm2-pet-menu-item .mute{color:#c2607f;font-size:12px;}',
   '.rm2-pet-menu-item .tick{color:#b03a60;font-weight:600;}',
   '.rm2-pet-menu-sep{height:1px;background:rgba(240,120,160,.25);margin:5px 6px;}',
-  '.rm2-pet-bubble{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:10px;min-width:150px;max-width:340px;padding:12px 20px 12px 30px;border-radius:22px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 8px 24px rgba(190,70,110,.22);font-size:12px;line-height:1.45;text-align:left;pointer-events:none;white-space:nowrap;text-overflow:ellipsis;cursor:default;}',
+  '.rm2-pet-bubble{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:13px;min-width:200px;max-width:453px;padding:16px 27px 16px 40px;border-radius:29px;corner-shape:round!important;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 11px 32px rgba(190,70,110,.22);font-size:16px;line-height:1.45;text-align:left;pointer-events:none;white-space:nowrap;text-overflow:ellipsis;cursor:default;}',
   '.rm2-pet-bubble-title{font-weight:600;color:#b03a60;}',
-  '.rm2-pet-bubble-detail{color:#c2607f;margin-top:2px;font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;}',
+  '.rm2-pet-bubble-detail{color:#c2607f;margin-top:3px;font-size:15px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;}',
   // 自绘悬停提示浮层：原生 title 不吃 setZoomFactor，高缩放屏（如 200%）上文字过小。
-  '.rm2-pet-tip{position:fixed;z-index:2147483400;box-sizing:border-box;max-width:min(420px,calc(100vw - 48px));padding:8px 12px;border-radius:10px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 8px 24px rgba(190,70,110,.22);font-family:system-ui,sans-serif;font-size:13px;line-height:1.5;color:#8a2f52;white-space:pre-wrap;word-break:break-all;display:none;pointer-events:none;}',
+  '.rm2-pet-tip{position:fixed;z-index:2147483400;box-sizing:border-box;max-width:min(420px,calc(100vw - 48px));padding:8px 12px;border-radius:10px;corner-shape:round!important;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 8px 24px rgba(190,70,110,.22);font-family:system-ui,sans-serif;font-size:13px;line-height:1.5;color:#8a2f52;white-space:pre-wrap;word-break:break-all;display:none;pointer-events:none;}',
   'body[data-ds-dark-theme] .rm2-pet-tip{background:rgba(72,20,42,.96);border-color:rgba(255,150,185,.42);color:#ffd6e4;}',
   // 气泡翻页圆点
-  '.rm2-bubble-dots{position:absolute;left:10px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;pointer-events:auto;z-index:120;}',
-  '.rm2-bubble-dot{width:10px;height:10px;border-radius:50%;background:#e8508a;cursor:pointer;box-shadow:0 0 0 2px rgba(255,255,255,.65);transition:transform .18s,background .18s;}',
+  '.rm2-bubble-dots{position:absolute;left:13px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;pointer-events:auto;z-index:120;}',
+  '.rm2-bubble-dot{width:13px;height:13px;border-radius:50%;corner-shape:round!important;background:#e8508a;cursor:pointer;box-shadow:0 0 0 3px rgba(255,255,255,.65);transition:transform .18s,background .18s;}',
   '.rm2-bubble-dot:hover{transform:scale(1.25);}',
-  '.rm2-pet-bubble::after{content:\"\";position:absolute;top:100%;left:50%;transform:translateX(-50%);border:6px solid transparent;border-top-color:rgba(240,120,160,.45);}',
+  '.rm2-pet-bubble::after{content:\"\";position:absolute;top:100%;left:50%;transform:translateX(-50%);corner-shape:round!important;border:8px solid transparent;border-top-color:rgba(240,120,160,.45);}',
   'body[data-ds-dark-theme] .rm2-pet-bubble{background:rgba(72,20,42,.96);border-color:rgba(255,150,185,.42);color:#ffd6e4;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble-title{color:#ffd6e4;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble-detail{color:#f0a8c0;}',
@@ -330,12 +398,12 @@ var CSS = [
   'body[data-ds-dark-theme] .rm2-pet-dl-bar-fill{background:#ffd6e4;}',
   // Confirmation dialog — modal overlay matching dsh style
   '.rm2-pet-confirm-overlay{position:fixed;inset:0;z-index:2147483200;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.35);}',
-  '.rm2-pet-confirm{width:min(380px,90vw);background:var(--dsw-alias-bg-overlay,#f8faff);border:1px solid var(--dsw-alias-border-l2,rgba(71,91,145,.3));border-radius:14px;box-shadow:0 20px 56px rgba(15,30,72,.34);padding:24px;font-family:system-ui,sans-serif;color:var(--dsw-alias-label-primary,#172347);}',
+  '.rm2-pet-confirm{width:min(380px,90vw);background:var(--dsw-alias-bg-overlay,#f8faff);border:1px solid var(--dsw-alias-border-l2,rgba(71,91,145,.3));border-radius:14px;corner-shape:round!important;box-shadow:0 20px 56px rgba(15,30,72,.34);padding:24px;font-family:system-ui,sans-serif;color:var(--dsw-alias-label-primary,#172347);}',
   '.rm2-pet-confirm-title{font-size:15px;font-weight:600;margin-bottom:8px;color:#b03a60;}',
   '.rm2-pet-confirm-body{font-size:13px;line-height:1.55;color:var(--dsw-alias-label-secondary,#6f7c99);margin-bottom:20px;}',
   '.rm2-pet-confirm-body b{color:#b03a60;}',
   '.rm2-pet-confirm-actions{display:flex;justify-content:flex-end;gap:10px;margin-top:16px;}',
-  '.rm2-pet-confirm-btn{padding:7px 18px;border-radius:8px;border:1px solid rgba(240,120,160,.3);background:transparent;color:#8a2f52;font-size:13px;cursor:pointer;font-family:inherit;transition:background .15s;}',
+  '.rm2-pet-confirm-btn{padding:7px 18px;border-radius:8px;corner-shape:round!important;border:1px solid rgba(240,120,160,.3);background:transparent;color:#8a2f52;font-size:13px;cursor:pointer;font-family:inherit;transition:background .15s;}',
   '.rm2-pet-confirm-btn:hover{background:rgba(240,120,160,.12);}',
   '.rm2-pet-confirm-btn.primary{background:#b03a60;color:#fff;border-color:#b03a60;}',
   '.rm2-pet-confirm-btn.primary:hover{background:#9a2e54;}',
@@ -351,8 +419,8 @@ var CSS = [
   'body[data-ds-dark-theme] .rm2-pet-menu-item .tick{color:#ffb3c9;}',
   'body[data-ds-dark-theme] .rm2-pet-menu-item:hover{background:rgba(255,150,185,.16);}',
   // Toggle switch — matches old zzz-pet-switch style
-  '.rm2-pet-switch{position:relative;flex:none;width:36px;height:20px;border-radius:999px;background:rgba(113,130,166,.45);cursor:pointer;transition:background .15s;border:none;padding:0;}',
-  '.rm2-pet-switch::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.3);transition:left .15s;}',
+  '.rm2-pet-switch{position:relative;flex:none;width:36px;height:20px;border-radius:999px;corner-shape:round!important;background:rgba(113,130,166,.45);cursor:pointer;transition:background .15s;border:none;padding:0;}',
+  '.rm2-pet-switch::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;corner-shape:round!important;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.3);transition:left .15s;}',
   '.rm2-pet-switch.on{background:var(--dsw-alias-brand-primary,#526aa8);}',
   '.rm2-pet-switch.on::after{left:18px;}',
   'body[data-ds-dark-theme] .rm2-pet-switch{background:rgba(150,166,201,.4);}',
@@ -363,19 +431,19 @@ var CSS = [
   '[data-testid="dsh-pet-remielle-settings"]:hover{border-color:var(--dsw-alias-label-dimmed);}',
   'body[data-ds-dark-theme] .rm2-pet-menu-sep{background:rgba(255,150,185,.25);}',
   // 堆叠会话卡（状态页）
-  '.rm2-pet-bubbles{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:12px;width:fit-content;max-width:min(330px,calc(100vw - 24px));display:flex;flex-direction:column;align-items:center;pointer-events:none;cursor:default;}',
-  '.rm2-pet-bubbles .rm2-pet-bubble{position:relative;bottom:auto;left:auto;transform:none;margin:0;box-sizing:border-box;width:fit-content;min-width:150px;max-width:min(330px,calc(100vw - 24px));height:68px;min-height:68px;padding:12px 20px 12px 30px;border-radius:22px;text-align:left;box-shadow:0 8px 24px rgba(190,70,110,.22);transition:width .18s ease,opacity .18s ease;}',
+  '.rm2-pet-bubbles{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:16px;width:fit-content;max-width:min(440px,calc(100vw - 24px));display:flex;flex-direction:column;align-items:center;pointer-events:none;cursor:default;}',
+  '.rm2-pet-bubbles .rm2-pet-bubble{position:relative;bottom:auto;left:auto;transform:none;margin:0;box-sizing:border-box;width:fit-content;min-width:200px;max-width:min(440px,calc(100vw - 24px));height:91px;min-height:91px;padding:16px 27px 16px 40px;border-radius:29px;corner-shape:round!important;text-align:left;box-shadow:0 11px 32px rgba(190,70,110,.22);transition:width .18s ease,opacity .18s ease;}',
   '.rm2-pet-bubbles .rm2-pet-bubble::after{display:none;}',
   '.rm2-pet-bubbles .rm2-pet-bubble{pointer-events:auto;cursor:pointer;}',
-  '.rm2-pet-bubble-header{display:flex;align-items:center;min-width:0;min-height:22px;}',
+  '.rm2-pet-bubble-header{display:flex;align-items:center;min-width:0;min-height:29px;}',
   '.rm2-pet-bubble-title{min-width:0;flex:none;white-space:nowrap;overflow:visible;text-overflow:clip;line-height:1.35;}',
   '.rm2-pet-bubble.title-clipped .rm2-pet-bubble-title{flex:1;overflow:hidden;text-overflow:ellipsis;}',
-  '.rm2-pet-bubble-action{display:inline-flex;flex:none;order:2;align-items:center;justify-content:center;width:22px;height:22px;margin-left:8px;margin-right:0;border-radius:50%;background:#e8508a;color:#fff;font-size:15px;font-weight:700;line-height:1;}',
-  '.rm2-pet-bubble-action img{width:15px;height:15px;display:block;filter:brightness(0) saturate(100%) invert(1);}',
-  '.rm2-pet-bubble-completion{display:none;flex:none;width:12px;height:12px;margin-right:10px;border-radius:50%;background:#35c979;box-shadow:0 0 0 3px rgba(53,201,121,.18);}',
+  '.rm2-pet-bubble-action{display:inline-flex;flex:none;order:2;align-items:center;justify-content:center;width:29px;height:29px;margin-left:11px;margin-right:0;border-radius:50%;corner-shape:round!important;background:#e8508a;color:#fff;font-size:20px;font-weight:700;line-height:1;}',
+  '.rm2-pet-bubble-action img{width:20px;height:20px;display:block;filter:brightness(0) saturate(100%) invert(1);}',
+  '.rm2-pet-bubble-completion{display:none;flex:none;width:16px;height:16px;margin-right:13px;border-radius:50%;corner-shape:round!important;background:#35c979;box-shadow:0 0 0 4px rgba(53,201,121,.18);}',
   '.rm2-pet-bubble.completed .rm2-pet-bubble-completion{display:inline-flex;}',
-  '.rm2-pet-bubble.idle-placeholder{height:46px;min-height:46px;padding-top:11px;padding-bottom:11px;}',
-  '.rm2-pet-bubble-stack-count{display:none;position:absolute;right:16px;bottom:0;height:8px;align-items:center;color:#f0a8c0;font-size:9px;font-weight:700;line-height:8px;}',
+  '.rm2-pet-bubble.idle-placeholder{height:61px;min-height:61px;padding-top:15px;padding-bottom:15px;}',
+  '.rm2-pet-bubble-stack-count{display:none;position:absolute;right:21px;bottom:0;height:11px;align-items:center;color:#f0a8c0;font-size:12px;font-weight:700;line-height:11px;}',
   '.rm2-pet-bubble.summary-backboard .rm2-pet-bubble-stack-count{display:flex;}',
   '.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-title,.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-detail,.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-action,.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-completion{visibility:hidden;}',
   '.rm2-pet-bubble.top{border-color:#b03a60;box-shadow:0 8px 24px rgba(190,70,110,.22);}',
@@ -388,8 +456,8 @@ var CSS = [
   '.rm2-pet-bubbles .rm2-pet-bubble{overflow:hidden;}',
   // 余额气泡复用对话卡工作态：border-box 同 68px 高度、max-width 与对话卡一致(330)、去掉气泡尾三角。
   // 标题行高 22px 对齐对话卡的 header(min-height 22px)。
-  '.rm2-bubble-balance{box-sizing:border-box;height:68px;min-height:68px;max-width:330px;}',
-  '.rm2-bubble-balance .rm2-pet-bubble-title{line-height:22px;min-width:0;overflow:hidden;text-overflow:ellipsis;}',
+  '.rm2-bubble-balance{box-sizing:border-box;height:91px;min-height:91px;max-width:440px;}',
+  '.rm2-bubble-balance .rm2-pet-bubble-title{line-height:29px;min-width:0;overflow:hidden;text-overflow:ellipsis;}',
   '.rm2-bubble-balance::after{display:none;}',
 ].join('\n')
 
@@ -1352,13 +1420,20 @@ function mountPet(ctx) {
   function onDotLeave(e) {
     __tip.onDotLeave(e, bubbleDot, bubbleDots, showPetTip, hidePetTip)
   }
+  function commitBackboardTarget(target, tip) {
+    var el = bubbleEls.get(BUBBLE_BACKBOARD_ID)
+    if (el && el.node) {
+      el.node.dataset.rm2Tip = tip
+      if (petTipAnchor === el.node) showPetTip(el.node)
+    }
+  }
   // 气泡框最小宽度：把标题在常见长度内的宽度变化"吸收"掉，避免方框频繁抖动
-  var BUBBLE_MIN_W = 208
+  var BUBBLE_MIN_W = 277
   // 两种方框（堆叠对话卡 / 余额气泡）共用同一宽度规则：取"最宽一行" + 内边距(50)，
-  // 下限 BUBBLE_MIN_W、上限 min(330, 视口-24)。返回含内边距的总宽。
+  // 下限 BUBBLE_MIN_W、上限 min(440, 视口-24)。返回含内边距的总宽。
   function bubbleRowWidth(textW) {
     var vw = Math.max(150, (window.innerWidth || 1280) - 24)
-    return Math.min(330, vw, Math.max(BUBBLE_MIN_W, textW + 50))
+    return Math.min(440, vw, Math.max(BUBBLE_MIN_W, textW + 67))
   }
   var currentBubblePage = 0
   function switchBubblePage(p) {
@@ -1506,6 +1581,8 @@ function mountPet(ctx) {
     var scale = snapshot.scale ?? 1
     var opacity = snapshot.opacity ?? 1
     img.style.width = Math.round(180 * scale) + 'px'
+    bubble.style.zoom = String(scale)
+    bubbleStack.style.zoom = String(scale)
     img.style.opacity = String(opacity)
     lockedNow = snapshot.locked === true
     syncPetCursor()
@@ -1518,7 +1595,13 @@ function mountPet(ctx) {
   var prevBubbleVisible = false
   // 牌叠第二层假背板的固定 sessionId（不对应真实会话，仅承载 +N 与点击跳转）。
   var BUBBLE_BACKBOARD_ID = '__pet_backboard__'
-  var backboardTarget = ''
+  var BACKBOARD_TIP_DEBOUNCE_MS = 400
+  var backboardStabilizer = __tip.createBackboardStabilizer(
+    commitBackboardTarget,
+    BACKBOARD_TIP_DEBOUNCE_MS,
+    function (fn, ms) { return window.setTimeout(fn, ms) },
+    function (timer) { window.clearTimeout(timer) },
+  )
   var currentSessionId = undefined
   var lastTopEntry = null
   var bubbleEls = new Map() // sessionId -> { node, title, detail }
@@ -1689,7 +1772,8 @@ function mountPet(ctx) {
       if (el.node.dataset.idlePlaceholder === 'true') return
       // 假背板：点击时按当帧排序动态解析第 2 名会话并跳转。
       if (el.targetSessionId === BUBBLE_BACKBOARD_ID) {
-        if (backboardTarget) openSession(backboardTarget, false)
+        var target = backboardStabilizer.target()
+        if (target) openSession(target, false)
         return
       }
       openSession(el.targetSessionId, el.completed)
@@ -1954,6 +2038,10 @@ function mountPet(ctx) {
     // 点击背板时按当帧排序动态解析第 2 名并跳转，这里只需记住它是谁。
     var visibleEntries = ordered.slice(0, 1)
     if (ordered.length > 1) {
+      backboardStabilizer.update(
+        targetSessionOf(ordered[1]) || '',
+        __tip.backboardTipText(ordered[1].project, ordered[1].title),
+      )
       visibleEntries.push({
         sessionId: BUBBLE_BACKBOARD_ID,
         state: 'IDLE',
@@ -1963,11 +2051,10 @@ function mountPet(ctx) {
         updatedAt: 0,
         backboard: true,
         summaryCount: ordered.length - 1,
-        backboardTip: __tip.backboardTipText(ordered[1].project, ordered[1].title),
+        backboardTip: backboardStabilizer.tip(),
       })
-      backboardTarget = targetSessionOf(ordered[1]) || ''
     } else {
-      backboardTarget = ''
+      backboardStabilizer.update('', '')
     }
     var count = visibleEntries.length
     var seen = new Set()
@@ -1982,14 +2069,14 @@ function mountPet(ctx) {
       var bubbleEl = ensureBubbleEl(entry.sessionId)
       if (bubbleEl.node.parentNode !== bubbleStack) bubbleStack.appendChild(bubbleEl.node)
       renderBubble(bubbleEl, entry, i)
-      bubbleEl.node.style.minWidth = '150px'
+      bubbleEl.node.style.minWidth = '200px'
       bubbleEl.node.style.width = 'max-content'
       bubbleEl.node.style.maxWidth = 'none'
       bubbleEl.node.classList.remove('title-clipped')
       var titleWidth = bubbleEl.title.scrollWidth || bubbleEl.title.offsetWidth || 0
       // 完成时鲸鱼图标保留显示，故恒计入其宽度（原先完成后隐藏鲸鱼时置 0）
-      var actionWidth = 30
-      var completionWidth = completionOf(entry) ? 22 : 0
+      var actionWidth = 40
+      var completionWidth = completionOf(entry) ? 29 : 0
       bubbleEl.naturalHeaderWidth = titleWidth + actionWidth + completionWidth
       // 宽度由两行中最宽的一行决定（标题行 或 详情行，取更宽者 + 内边距）；上限由下文 min(330,viewport) 截断，
       // 只有超出该上限时才由详情行的省略号截断，符合「最宽行决定宽度 + 最大宽度限制」的设计。
@@ -2005,7 +2092,7 @@ function mountPet(ctx) {
       var renderEntry = visibleEntries[j]
       var renderEl = bubbleEls.get(renderEntry.sessionId)
       renderBubble(renderEl, renderEntry, j)
-      renderEl.node.classList.toggle('title-clipped', renderEl.naturalHeaderWidth > Math.max(0, deckWidth - 50))
+      renderEl.node.classList.toggle('title-clipped', renderEl.naturalHeaderWidth > Math.max(0, deckWidth - 67))
     }
     for (var key of bubbleEls.keys()) {
       if (!seen.has(key)) {

--- a/src/client.core.js
+++ b/src/client.core.js
@@ -76,23 +76,23 @@ function withPrefix(p) { return RM_GATEWAY_PREFIX + p }
 var CSS = [
   // Right-click menu — pink palette, matching the status bubble on both the
   // in-page pet and the desktop window (hardcoded, not DSW vars).
-  '.rm2-pet-menu{position:fixed;z-index:2147483000;min-width:200px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);border-radius:10px;box-shadow:0 8px 24px rgba(190,70,110,.22);padding:6px;font-family:system-ui,sans-serif;font-size:13px;color:#8a2f52;display:none;user-select:none;}',
-  '.rm2-pet-menu-item{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:7px 10px;border-radius:7px;cursor:pointer;white-space:nowrap;}',
+  '.rm2-pet-menu{position:fixed;z-index:2147483000;min-width:200px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);border-radius:10px;corner-shape:round!important;box-shadow:0 8px 24px rgba(190,70,110,.22);padding:6px;font-family:system-ui,sans-serif;font-size:13px;color:#8a2f52;display:none;user-select:none;}',
+  '.rm2-pet-menu-item{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:7px 10px;border-radius:7px;corner-shape:round!important;cursor:pointer;white-space:nowrap;}',
   '.rm2-pet-menu-item:hover{background:rgba(240,120,160,.14);}',
   '.rm2-pet-menu-item .mute{color:#c2607f;font-size:12px;}',
   '.rm2-pet-menu-item .tick{color:#b03a60;font-weight:600;}',
   '.rm2-pet-menu-sep{height:1px;background:rgba(240,120,160,.25);margin:5px 6px;}',
-  '.rm2-pet-bubble{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:10px;min-width:150px;max-width:340px;padding:12px 20px 12px 30px;border-radius:22px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 8px 24px rgba(190,70,110,.22);font-size:12px;line-height:1.45;text-align:left;pointer-events:none;white-space:nowrap;text-overflow:ellipsis;cursor:default;}',
+  '.rm2-pet-bubble{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:13px;min-width:200px;max-width:453px;padding:16px 27px 16px 40px;border-radius:29px;corner-shape:round!important;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 11px 32px rgba(190,70,110,.22);font-size:16px;line-height:1.45;text-align:left;pointer-events:none;white-space:nowrap;text-overflow:ellipsis;cursor:default;}',
   '.rm2-pet-bubble-title{font-weight:600;color:#b03a60;}',
-  '.rm2-pet-bubble-detail{color:#c2607f;margin-top:2px;font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;}',
+  '.rm2-pet-bubble-detail{color:#c2607f;margin-top:3px;font-size:15px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;}',
   // 自绘悬停提示浮层：原生 title 不吃 setZoomFactor，高缩放屏（如 200%）上文字过小。
-  '.rm2-pet-tip{position:fixed;z-index:2147483400;box-sizing:border-box;max-width:min(420px,calc(100vw - 48px));padding:8px 12px;border-radius:10px;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 8px 24px rgba(190,70,110,.22);font-family:system-ui,sans-serif;font-size:13px;line-height:1.5;color:#8a2f52;white-space:pre-wrap;word-break:break-all;display:none;pointer-events:none;}',
+  '.rm2-pet-tip{position:fixed;z-index:2147483400;box-sizing:border-box;max-width:min(420px,calc(100vw - 48px));padding:8px 12px;border-radius:10px;corner-shape:round!important;background:#fff0f5;border:1px solid rgba(240,120,160,.45);box-shadow:0 8px 24px rgba(190,70,110,.22);font-family:system-ui,sans-serif;font-size:13px;line-height:1.5;color:#8a2f52;white-space:pre-wrap;word-break:break-all;display:none;pointer-events:none;}',
   'body[data-ds-dark-theme] .rm2-pet-tip{background:rgba(72,20,42,.96);border-color:rgba(255,150,185,.42);color:#ffd6e4;}',
   // 气泡翻页圆点
-  '.rm2-bubble-dots{position:absolute;left:10px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;pointer-events:auto;z-index:120;}',
-  '.rm2-bubble-dot{width:10px;height:10px;border-radius:50%;background:#e8508a;cursor:pointer;box-shadow:0 0 0 2px rgba(255,255,255,.65);transition:transform .18s,background .18s;}',
+  '.rm2-bubble-dots{position:absolute;left:13px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;pointer-events:auto;z-index:120;}',
+  '.rm2-bubble-dot{width:13px;height:13px;border-radius:50%;corner-shape:round!important;background:#e8508a;cursor:pointer;box-shadow:0 0 0 3px rgba(255,255,255,.65);transition:transform .18s,background .18s;}',
   '.rm2-bubble-dot:hover{transform:scale(1.25);}',
-  '.rm2-pet-bubble::after{content:\"\";position:absolute;top:100%;left:50%;transform:translateX(-50%);border:6px solid transparent;border-top-color:rgba(240,120,160,.45);}',
+  '.rm2-pet-bubble::after{content:\"\";position:absolute;top:100%;left:50%;transform:translateX(-50%);corner-shape:round!important;border:8px solid transparent;border-top-color:rgba(240,120,160,.45);}',
   'body[data-ds-dark-theme] .rm2-pet-bubble{background:rgba(72,20,42,.96);border-color:rgba(255,150,185,.42);color:#ffd6e4;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble-title{color:#ffd6e4;}',
   'body[data-ds-dark-theme] .rm2-pet-bubble-detail{color:#f0a8c0;}',
@@ -106,12 +106,12 @@ var CSS = [
   'body[data-ds-dark-theme] .rm2-pet-dl-bar-fill{background:#ffd6e4;}',
   // Confirmation dialog — modal overlay matching dsh style
   '.rm2-pet-confirm-overlay{position:fixed;inset:0;z-index:2147483200;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.35);}',
-  '.rm2-pet-confirm{width:min(380px,90vw);background:var(--dsw-alias-bg-overlay,#f8faff);border:1px solid var(--dsw-alias-border-l2,rgba(71,91,145,.3));border-radius:14px;box-shadow:0 20px 56px rgba(15,30,72,.34);padding:24px;font-family:system-ui,sans-serif;color:var(--dsw-alias-label-primary,#172347);}',
+  '.rm2-pet-confirm{width:min(380px,90vw);background:var(--dsw-alias-bg-overlay,#f8faff);border:1px solid var(--dsw-alias-border-l2,rgba(71,91,145,.3));border-radius:14px;corner-shape:round!important;box-shadow:0 20px 56px rgba(15,30,72,.34);padding:24px;font-family:system-ui,sans-serif;color:var(--dsw-alias-label-primary,#172347);}',
   '.rm2-pet-confirm-title{font-size:15px;font-weight:600;margin-bottom:8px;color:#b03a60;}',
   '.rm2-pet-confirm-body{font-size:13px;line-height:1.55;color:var(--dsw-alias-label-secondary,#6f7c99);margin-bottom:20px;}',
   '.rm2-pet-confirm-body b{color:#b03a60;}',
   '.rm2-pet-confirm-actions{display:flex;justify-content:flex-end;gap:10px;margin-top:16px;}',
-  '.rm2-pet-confirm-btn{padding:7px 18px;border-radius:8px;border:1px solid rgba(240,120,160,.3);background:transparent;color:#8a2f52;font-size:13px;cursor:pointer;font-family:inherit;transition:background .15s;}',
+  '.rm2-pet-confirm-btn{padding:7px 18px;border-radius:8px;corner-shape:round!important;border:1px solid rgba(240,120,160,.3);background:transparent;color:#8a2f52;font-size:13px;cursor:pointer;font-family:inherit;transition:background .15s;}',
   '.rm2-pet-confirm-btn:hover{background:rgba(240,120,160,.12);}',
   '.rm2-pet-confirm-btn.primary{background:#b03a60;color:#fff;border-color:#b03a60;}',
   '.rm2-pet-confirm-btn.primary:hover{background:#9a2e54;}',
@@ -127,8 +127,8 @@ var CSS = [
   'body[data-ds-dark-theme] .rm2-pet-menu-item .tick{color:#ffb3c9;}',
   'body[data-ds-dark-theme] .rm2-pet-menu-item:hover{background:rgba(255,150,185,.16);}',
   // Toggle switch — matches old zzz-pet-switch style
-  '.rm2-pet-switch{position:relative;flex:none;width:36px;height:20px;border-radius:999px;background:rgba(113,130,166,.45);cursor:pointer;transition:background .15s;border:none;padding:0;}',
-  '.rm2-pet-switch::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.3);transition:left .15s;}',
+  '.rm2-pet-switch{position:relative;flex:none;width:36px;height:20px;border-radius:999px;corner-shape:round!important;background:rgba(113,130,166,.45);cursor:pointer;transition:background .15s;border:none;padding:0;}',
+  '.rm2-pet-switch::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;corner-shape:round!important;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.3);transition:left .15s;}',
   '.rm2-pet-switch.on{background:var(--dsw-alias-brand-primary,#526aa8);}',
   '.rm2-pet-switch.on::after{left:18px;}',
   'body[data-ds-dark-theme] .rm2-pet-switch{background:rgba(150,166,201,.4);}',
@@ -139,19 +139,19 @@ var CSS = [
   '[data-testid="dsh-pet-remielle-settings"]:hover{border-color:var(--dsw-alias-label-dimmed);}',
   'body[data-ds-dark-theme] .rm2-pet-menu-sep{background:rgba(255,150,185,.25);}',
   // 堆叠会话卡（状态页）
-  '.rm2-pet-bubbles{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:12px;width:fit-content;max-width:min(330px,calc(100vw - 24px));display:flex;flex-direction:column;align-items:center;pointer-events:none;cursor:default;}',
-  '.rm2-pet-bubbles .rm2-pet-bubble{position:relative;bottom:auto;left:auto;transform:none;margin:0;box-sizing:border-box;width:fit-content;min-width:150px;max-width:min(330px,calc(100vw - 24px));height:68px;min-height:68px;padding:12px 20px 12px 30px;border-radius:22px;text-align:left;box-shadow:0 8px 24px rgba(190,70,110,.22);transition:width .18s ease,opacity .18s ease;}',
+  '.rm2-pet-bubbles{position:absolute;bottom:100%;left:50%;transform:translateX(-50%);margin-bottom:16px;width:fit-content;max-width:min(440px,calc(100vw - 24px));display:flex;flex-direction:column;align-items:center;pointer-events:none;cursor:default;}',
+  '.rm2-pet-bubbles .rm2-pet-bubble{position:relative;bottom:auto;left:auto;transform:none;margin:0;box-sizing:border-box;width:fit-content;min-width:200px;max-width:min(440px,calc(100vw - 24px));height:91px;min-height:91px;padding:16px 27px 16px 40px;border-radius:29px;corner-shape:round!important;text-align:left;box-shadow:0 11px 32px rgba(190,70,110,.22);transition:width .18s ease,opacity .18s ease;}',
   '.rm2-pet-bubbles .rm2-pet-bubble::after{display:none;}',
   '.rm2-pet-bubbles .rm2-pet-bubble{pointer-events:auto;cursor:pointer;}',
-  '.rm2-pet-bubble-header{display:flex;align-items:center;min-width:0;min-height:22px;}',
+  '.rm2-pet-bubble-header{display:flex;align-items:center;min-width:0;min-height:29px;}',
   '.rm2-pet-bubble-title{min-width:0;flex:none;white-space:nowrap;overflow:visible;text-overflow:clip;line-height:1.35;}',
   '.rm2-pet-bubble.title-clipped .rm2-pet-bubble-title{flex:1;overflow:hidden;text-overflow:ellipsis;}',
-  '.rm2-pet-bubble-action{display:inline-flex;flex:none;order:2;align-items:center;justify-content:center;width:22px;height:22px;margin-left:8px;margin-right:0;border-radius:50%;background:#e8508a;color:#fff;font-size:15px;font-weight:700;line-height:1;}',
-  '.rm2-pet-bubble-action img{width:15px;height:15px;display:block;filter:brightness(0) saturate(100%) invert(1);}',
-  '.rm2-pet-bubble-completion{display:none;flex:none;width:12px;height:12px;margin-right:10px;border-radius:50%;background:#35c979;box-shadow:0 0 0 3px rgba(53,201,121,.18);}',
+  '.rm2-pet-bubble-action{display:inline-flex;flex:none;order:2;align-items:center;justify-content:center;width:29px;height:29px;margin-left:11px;margin-right:0;border-radius:50%;corner-shape:round!important;background:#e8508a;color:#fff;font-size:20px;font-weight:700;line-height:1;}',
+  '.rm2-pet-bubble-action img{width:20px;height:20px;display:block;filter:brightness(0) saturate(100%) invert(1);}',
+  '.rm2-pet-bubble-completion{display:none;flex:none;width:16px;height:16px;margin-right:13px;border-radius:50%;corner-shape:round!important;background:#35c979;box-shadow:0 0 0 4px rgba(53,201,121,.18);}',
   '.rm2-pet-bubble.completed .rm2-pet-bubble-completion{display:inline-flex;}',
-  '.rm2-pet-bubble.idle-placeholder{height:46px;min-height:46px;padding-top:11px;padding-bottom:11px;}',
-  '.rm2-pet-bubble-stack-count{display:none;position:absolute;right:16px;bottom:0;height:8px;align-items:center;color:#f0a8c0;font-size:9px;font-weight:700;line-height:8px;}',
+  '.rm2-pet-bubble.idle-placeholder{height:61px;min-height:61px;padding-top:15px;padding-bottom:15px;}',
+  '.rm2-pet-bubble-stack-count{display:none;position:absolute;right:21px;bottom:0;height:11px;align-items:center;color:#f0a8c0;font-size:12px;font-weight:700;line-height:11px;}',
   '.rm2-pet-bubble.summary-backboard .rm2-pet-bubble-stack-count{display:flex;}',
   '.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-title,.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-detail,.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-action,.rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-completion{visibility:hidden;}',
   '.rm2-pet-bubble.top{border-color:#b03a60;box-shadow:0 8px 24px rgba(190,70,110,.22);}',
@@ -164,8 +164,8 @@ var CSS = [
   '.rm2-pet-bubbles .rm2-pet-bubble{overflow:hidden;}',
   // 余额气泡复用对话卡工作态：border-box 同 68px 高度、max-width 与对话卡一致(330)、去掉气泡尾三角。
   // 标题行高 22px 对齐对话卡的 header(min-height 22px)。
-  '.rm2-bubble-balance{box-sizing:border-box;height:68px;min-height:68px;max-width:330px;}',
-  '.rm2-bubble-balance .rm2-pet-bubble-title{line-height:22px;min-width:0;overflow:hidden;text-overflow:ellipsis;}',
+  '.rm2-bubble-balance{box-sizing:border-box;height:91px;min-height:91px;max-width:440px;}',
+  '.rm2-bubble-balance .rm2-pet-bubble-title{line-height:29px;min-width:0;overflow:hidden;text-overflow:ellipsis;}',
   '.rm2-bubble-balance::after{display:none;}',
 ].join('\n')
 
@@ -1128,13 +1128,20 @@ function mountPet(ctx) {
   function onDotLeave(e) {
     __tip.onDotLeave(e, bubbleDot, bubbleDots, showPetTip, hidePetTip)
   }
+  function commitBackboardTarget(target, tip) {
+    var el = bubbleEls.get(BUBBLE_BACKBOARD_ID)
+    if (el && el.node) {
+      el.node.dataset.rm2Tip = tip
+      if (petTipAnchor === el.node) showPetTip(el.node)
+    }
+  }
   // 气泡框最小宽度：把标题在常见长度内的宽度变化"吸收"掉，避免方框频繁抖动
-  var BUBBLE_MIN_W = 208
+  var BUBBLE_MIN_W = 277
   // 两种方框（堆叠对话卡 / 余额气泡）共用同一宽度规则：取"最宽一行" + 内边距(50)，
-  // 下限 BUBBLE_MIN_W、上限 min(330, 视口-24)。返回含内边距的总宽。
+  // 下限 BUBBLE_MIN_W、上限 min(440, 视口-24)。返回含内边距的总宽。
   function bubbleRowWidth(textW) {
     var vw = Math.max(150, (window.innerWidth || 1280) - 24)
-    return Math.min(330, vw, Math.max(BUBBLE_MIN_W, textW + 50))
+    return Math.min(440, vw, Math.max(BUBBLE_MIN_W, textW + 67))
   }
   var currentBubblePage = 0
   function switchBubblePage(p) {
@@ -1282,6 +1289,8 @@ function mountPet(ctx) {
     var scale = snapshot.scale ?? 1
     var opacity = snapshot.opacity ?? 1
     img.style.width = Math.round(180 * scale) + 'px'
+    bubble.style.zoom = String(scale)
+    bubbleStack.style.zoom = String(scale)
     img.style.opacity = String(opacity)
     lockedNow = snapshot.locked === true
     syncPetCursor()
@@ -1294,7 +1303,13 @@ function mountPet(ctx) {
   var prevBubbleVisible = false
   // 牌叠第二层假背板的固定 sessionId（不对应真实会话，仅承载 +N 与点击跳转）。
   var BUBBLE_BACKBOARD_ID = '__pet_backboard__'
-  var backboardTarget = ''
+  var BACKBOARD_TIP_DEBOUNCE_MS = 400
+  var backboardStabilizer = __tip.createBackboardStabilizer(
+    commitBackboardTarget,
+    BACKBOARD_TIP_DEBOUNCE_MS,
+    function (fn, ms) { return window.setTimeout(fn, ms) },
+    function (timer) { window.clearTimeout(timer) },
+  )
   var currentSessionId = undefined
   var lastTopEntry = null
   var bubbleEls = new Map() // sessionId -> { node, title, detail }
@@ -1465,7 +1480,8 @@ function mountPet(ctx) {
       if (el.node.dataset.idlePlaceholder === 'true') return
       // 假背板：点击时按当帧排序动态解析第 2 名会话并跳转。
       if (el.targetSessionId === BUBBLE_BACKBOARD_ID) {
-        if (backboardTarget) openSession(backboardTarget, false)
+        var target = backboardStabilizer.target()
+        if (target) openSession(target, false)
         return
       }
       openSession(el.targetSessionId, el.completed)
@@ -1730,6 +1746,10 @@ function mountPet(ctx) {
     // 点击背板时按当帧排序动态解析第 2 名并跳转，这里只需记住它是谁。
     var visibleEntries = ordered.slice(0, 1)
     if (ordered.length > 1) {
+      backboardStabilizer.update(
+        targetSessionOf(ordered[1]) || '',
+        __tip.backboardTipText(ordered[1].project, ordered[1].title),
+      )
       visibleEntries.push({
         sessionId: BUBBLE_BACKBOARD_ID,
         state: 'IDLE',
@@ -1739,11 +1759,10 @@ function mountPet(ctx) {
         updatedAt: 0,
         backboard: true,
         summaryCount: ordered.length - 1,
-        backboardTip: __tip.backboardTipText(ordered[1].project, ordered[1].title),
+        backboardTip: backboardStabilizer.tip(),
       })
-      backboardTarget = targetSessionOf(ordered[1]) || ''
     } else {
-      backboardTarget = ''
+      backboardStabilizer.update('', '')
     }
     var count = visibleEntries.length
     var seen = new Set()
@@ -1758,14 +1777,14 @@ function mountPet(ctx) {
       var bubbleEl = ensureBubbleEl(entry.sessionId)
       if (bubbleEl.node.parentNode !== bubbleStack) bubbleStack.appendChild(bubbleEl.node)
       renderBubble(bubbleEl, entry, i)
-      bubbleEl.node.style.minWidth = '150px'
+      bubbleEl.node.style.minWidth = '200px'
       bubbleEl.node.style.width = 'max-content'
       bubbleEl.node.style.maxWidth = 'none'
       bubbleEl.node.classList.remove('title-clipped')
       var titleWidth = bubbleEl.title.scrollWidth || bubbleEl.title.offsetWidth || 0
       // 完成时鲸鱼图标保留显示，故恒计入其宽度（原先完成后隐藏鲸鱼时置 0）
-      var actionWidth = 30
-      var completionWidth = completionOf(entry) ? 22 : 0
+      var actionWidth = 40
+      var completionWidth = completionOf(entry) ? 29 : 0
       bubbleEl.naturalHeaderWidth = titleWidth + actionWidth + completionWidth
       // 宽度由两行中最宽的一行决定（标题行 或 详情行，取更宽者 + 内边距）；上限由下文 min(330,viewport) 截断，
       // 只有超出该上限时才由详情行的省略号截断，符合「最宽行决定宽度 + 最大宽度限制」的设计。
@@ -1781,7 +1800,7 @@ function mountPet(ctx) {
       var renderEntry = visibleEntries[j]
       var renderEl = bubbleEls.get(renderEntry.sessionId)
       renderBubble(renderEl, renderEntry, j)
-      renderEl.node.classList.toggle('title-clipped', renderEl.naturalHeaderWidth > Math.max(0, deckWidth - 50))
+      renderEl.node.classList.toggle('title-clipped', renderEl.naturalHeaderWidth > Math.max(0, deckWidth - 67))
     }
     for (var key of bubbleEls.keys()) {
       if (!seen.has(key)) {

--- a/src/desktop-window.js
+++ b/src/desktop-window.js
@@ -193,6 +193,13 @@ export class DesktopWindow {
       },
     })
     this.child = child
+    let exitNotified = false
+    const notifyExit = () => {
+      if (exitNotified) return
+      exitNotified = true
+      if (this.child === child) this.child = undefined
+      this.onExit?.()
+    }
     const forward = (stream, dest) => {
       if (!stream || typeof stream.on !== 'function' || !dest || typeof dest.write !== 'function') return
       stream.on('data', (chunk) => {
@@ -205,11 +212,10 @@ export class DesktopWindow {
     forward(child.stderr, process.stderr)
     child.once('error', (error) => {
       this.logger.error?.(`dsh-pet-remielle: pet window failed to start: ${error.message}`)
-      this.child = undefined
+      notifyExit()
     })
     child.once('exit', () => {
-      if (this.child === child) this.child = undefined
-      this.onExit?.()
+      notifyExit()
     })
     return child
   }

--- a/src/index.js
+++ b/src/index.js
@@ -917,7 +917,7 @@ function mount(ctx, config = {}, eventCtx = ctx) {
   void refreshRegistry()
 
   if (typeof ctx.inject === 'function') {
-    ctx.inject(['webServer'], (httpCtx) => {
+    ctx.inject(['webServer', 'connection'], (httpCtx) => {
       const port = httpCtx.webServer.port
 
       // ---- desktop pet window (transparent always-on-top Electron) ----
@@ -932,20 +932,8 @@ function mount(ctx, config = {}, eventCtx = ctx) {
       }
       const origin = `http://127.0.0.1:${port}`
       const desktopUrl = `${origin}${PET_VIEW_ENDPOINT}`
-      // DSH 0.1.2-alpha.1 起 Web 壳根路径要带进程 token；旧宿主没有该方法则仍打开 origin。
-      // 容错：authenticatedUrl 在个别宿主/会话态下可能抛错；失败时回落 origin，
-      // 避免 startDesktop 因此抛异常导致桌面窗根本起不来。
-      const dshWebUrl = () => {
-        try {
-          const connection = ctx.connection
-          return typeof connection?.authenticatedUrl === 'function'
-            ? connection.authenticatedUrl(origin)
-            : origin
-        } catch (error) {
-          logger.warn?.(`dsh-pet-remielle: dshWebUrl() 失败，回落 origin（${String(error)}）`)
-          return origin
-        }
-      }
+      // DSH 0.1.2-alpha.1 起 Web 壳根路径必须通过 connection 带进程 token。
+      const dshWebUrl = () => httpCtx.connection.authenticatedUrl(origin)
       const onDesktopExit = () => {
         desktop = undefined
         if (desktopActive) { desktopActive = false; hub.broadcast() }

--- a/src/pet-tip.cjs
+++ b/src/pet-tip.cjs
@@ -22,6 +22,72 @@
     return '点击去看 ' + parts.join(' · ') + ' 哦~'
   }
 
+  // 让背板的点击目标和提示文字成对更新，并在候选目标稳定后再提交。
+  function createBackboardStabilizer(commit, delay, schedule, cancel) {
+    var currentTarget = ''
+    var currentTip = ''
+    var pendingTarget = ''
+    var pendingTip = ''
+    var timer = 0
+    var commitFn = typeof commit === 'function' ? commit : function () {}
+    var scheduleFn = typeof schedule === 'function' ? schedule : function (fn, ms) { return setTimeout(fn, ms) }
+    var cancelFn = typeof cancel === 'function' ? cancel : function (id) { clearTimeout(id) }
+
+    function clearTimer() {
+      if (!timer) return
+      cancelFn(timer)
+      timer = 0
+    }
+
+    function commitNow(target, tip) {
+      clearTimer()
+      currentTarget = target
+      currentTip = tip
+      pendingTarget = ''
+      pendingTip = ''
+      commitFn(target, tip)
+    }
+
+    function update(target, tip) {
+      target = String(target || '')
+      tip = String(tip || '')
+      if (!target) {
+        commitNow('', '')
+        return
+      }
+      if (target === currentTarget && tip === currentTip) {
+        pendingTarget = ''
+        pendingTip = ''
+        clearTimer()
+        return
+      }
+      if (!currentTarget) {
+        commitNow(target, tip)
+        return
+      }
+      pendingTarget = target
+      pendingTip = tip
+      clearTimer()
+      timer = scheduleFn(function () {
+        timer = 0
+        commitNow(pendingTarget, pendingTip)
+      }, delay)
+    }
+
+    return {
+      update: update,
+      target: function () { return currentTarget },
+      tip: function () { return currentTip },
+      clear: clearTimer,
+    }
+  }
+
+  function openIdleDshPage(bridge) {
+    if (!bridge || typeof bridge.openDshPage !== 'function') return false
+    bridge.openDshPage()
+    return true
+  }
+
   function applyDotTip(dot, page, anchor, show) {
     if (!dot || !dot.dataset) return
     dot.dataset.rm2Tip = dotTipText(page)
@@ -102,6 +168,8 @@
   global.__rm2PetTip = {
     dotTipText: dotTipText,
     backboardTipText: backboardTipText,
+    createBackboardStabilizer: createBackboardStabilizer,
+    openIdleDshPage: openIdleDshPage,
     applyDotTip: applyDotTip,
     onDotLeave: onDotLeave,
     layoutPetTip: layoutPetTip,

--- a/src/pet-view.html
+++ b/src/pet-view.html
@@ -38,9 +38,9 @@
   }
   .rm2-pet-bubbles {
     position: relative;
-    margin-bottom: 12px;
+    margin-bottom: 16px;
     width: fit-content;
-    max-width: min(330px, calc(100vw - 24px));
+    max-width: min(440px, calc(100vw - 24px));
     display: none;
     flex-direction: column;
     align-items: center;
@@ -50,16 +50,16 @@
   .rm2-pet-bubble {
     display: none;
     position: relative;
-    margin-bottom: 10px;
+    margin-bottom: 13px;
     box-sizing: border-box;
-    min-width: 150px;
-    max-width: min(330px, calc(100vw - 24px));
-    padding: 12px 20px 12px 30px;
-    border-radius: 22px;
+    min-width: 200px;
+    max-width: min(440px, calc(100vw - 24px));
+    padding: 16px 27px 16px 40px;
+    border-radius: 29px;
     background: #fff0f5;
     border: 1px solid rgba(240, 120, 160, .45);
     box-shadow: var(--rm2-glow);
-    font-size: 12px;
+    font-size: 16px;
     line-height: 1.45;
     text-align: left;
     white-space: nowrap;
@@ -68,8 +68,8 @@
   .rm2-pet-bubbles .rm2-pet-bubble {
     margin: 0;
     width: fit-content;
-    height: 68px;
-    min-height: 68px;
+    height: 91px;
+    min-height: 91px;
     box-shadow: var(--rm2-glow);
     pointer-events: auto;
     cursor: pointer;
@@ -77,7 +77,7 @@
     transition: width .18s ease, opacity .18s ease;
   }
   .rm2-pet-bubble-title { font-weight: 600; color: #b03a60; min-width: 0; flex: none; white-space: nowrap; overflow: visible; text-overflow: clip; line-height: 1.35; }
-  .rm2-pet-bubble-detail { color: #c2607f; margin-top: 2px; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+  .rm2-pet-bubble-detail { color: #c2607f; margin-top: 3px; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
   /* 自绘悬停提示浮层：原生 title 不吃 setZoomFactor，高缩放屏（如 200%）上文字过小。
      阴影与菜单同套，不用网页 8/24。 */
   .rm2-pet-tip {
@@ -97,13 +97,13 @@
   @media (prefers-color-scheme: dark) {
     .rm2-pet-tip { background: #48142a; border-color: rgba(255, 150, 185, .42); color: #ffd6e4; }
   }
-  .rm2-pet-bubble-header { display: flex; align-items: center; min-width: 0; min-height: 22px; }
+  .rm2-pet-bubble-header { display: flex; align-items: center; min-width: 0; min-height: 29px; }
   .rm2-pet-bubble.title-clipped .rm2-pet-bubble-title { flex: 1; overflow: hidden; text-overflow: ellipsis; }
-  .rm2-pet-bubble-action { display: inline-flex; flex: none; order: 2; align-items: center; justify-content: center; width: 22px; height: 22px; margin-left: 8px; margin-right: 0; border-radius: 50%; background: #e8508a; color: #fff; font-size: 15px; font-weight: 700; line-height: 1; }
-  .rm2-pet-bubble-action img { width: 15px; height: 15px; display: block; filter: brightness(0) saturate(100%) invert(1); }
-  .rm2-pet-bubble-completion { display: none; flex: none; width: 12px; height: 12px; margin-right: 10px; border-radius: 50%; background: #35c979; box-shadow: 0 0 0 3px rgba(53,201,121,.18); }
+  .rm2-pet-bubble-action { display: inline-flex; flex: none; order: 2; align-items: center; justify-content: center; width: 29px; height: 29px; margin-left: 11px; margin-right: 0; border-radius: 50%; background: #e8508a; color: #fff; font-size: 20px; font-weight: 700; line-height: 1; }
+  .rm2-pet-bubble-action img { width: 20px; height: 20px; display: block; filter: brightness(0) saturate(100%) invert(1); }
+  .rm2-pet-bubble-completion { display: none; flex: none; width: 16px; height: 16px; margin-right: 13px; border-radius: 50%; background: #35c979; box-shadow: 0 0 0 4px rgba(53,201,121,.18); }
   .rm2-pet-bubble.completed .rm2-pet-bubble-completion { display: inline-flex; }
-  .rm2-pet-bubble.idle-placeholder { height: 46px; min-height: 46px; padding-top: 11px; padding-bottom: 11px; }
+  .rm2-pet-bubble.idle-placeholder { height: 61px; min-height: 61px; padding-top: 15px; padding-bottom: 15px; }
   .rm2-pet-bubble-stack-count { display: none; position: absolute; right: 16px; bottom: 0; height: 8px; align-items: center; color: #f0a8c0; font-size: 9px; font-weight: 700; line-height: 8px; }
   .rm2-pet-bubble.summary-backboard .rm2-pet-bubble-stack-count { display: flex; }
   .rm2-pet-bubbles .rm2-pet-bubble:not(.top) .rm2-pet-bubble-title,
@@ -116,8 +116,8 @@
   .rm2-bubble-dots { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); display: flex; align-items: center; justify-content: center; pointer-events: auto; z-index: 120; }
   .rm2-bubble-dot { width: 10px; height: 10px; border-radius: 50%; background: #e8508a; cursor: pointer; box-shadow: 0 0 0 2px rgba(255,255,255,.65); transition: transform .18s, background .18s; }
   .rm2-bubble-dot:hover { transform: scale(1.25); }
-  .rm2-bubble-balance { box-sizing: border-box; height: 68px; min-height: 68px; max-width: 330px; }
-  .rm2-bubble-balance .rm2-pet-bubble-title { line-height: 22px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+  .rm2-bubble-balance { box-sizing: border-box; height: 91px; min-height: 91px; max-width: 440px; }
+  .rm2-bubble-balance .rm2-pet-bubble-title { line-height: 29px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
   img { width: 180px; height: auto; display: block; }
   /* 审批未送达 toast：单例提示条，悬在气泡堆叠上方（bottom 由 JS 按堆叠实时计算）；
      pointer-events 放行桌面点击，z-index 低于右键菜单（#menu:999） */
@@ -217,10 +217,10 @@
   var balanceRequested = false
   var SESSION_OPEN_ENDPOINT = '/plugins/dsh-pet-remielle/session/open'
   var COMPLETION_ACK_ENDPOINT = '/plugins/dsh-pet-remielle/completion/ack'
-  var BUBBLE_MIN_W = 208
+  var BUBBLE_MIN_W = 277
   // 牌叠第二层假背板的固定 sessionId（不对应真实会话，仅承载 +N 与点击跳转）。
   var BUBBLE_BACKBOARD_ID = '__pet_backboard__'
-  var backboardTarget = ''
+  var BACKBOARD_TIP_DEBOUNCE_MS = 400
   // 当前会话完成卡的自动 ack 标记（sessionId -> true）：见 updateBubbles 内说明
   var autoAckedCompletions = new Map()
   var currentSessionId = undefined
@@ -279,6 +279,19 @@
   function onDotLeave(e) {
     __tip.onDotLeave(e, bubbleDot, bubbleDots, showPetTip, hidePetTip)
   }
+  function commitBackboardTarget(target, tip) {
+    var el = bubbleEls.get(BUBBLE_BACKBOARD_ID)
+    if (el && el.node) {
+      el.node.dataset.rm2Tip = tip
+      if (petTipAnchor === el.node) showPetTip(el.node)
+    }
+  }
+  var backboardStabilizer = __tip.createBackboardStabilizer(
+    commitBackboardTarget,
+    BACKBOARD_TIP_DEBOUNCE_MS,
+    function (fn, ms) { return window.setTimeout(fn, ms) },
+    function (timer) { window.clearTimeout(timer) },
+  )
   var __petMeasureEl = null
   function ensureMeasureEl() {
     if (!__petMeasureEl) {
@@ -302,7 +315,7 @@
   }
   function bubbleRowWidth(textW) {
     var vw = Math.max(150, (window.innerWidth || 1280) - 24)
-    return Math.min(330, vw, Math.max(BUBBLE_MIN_W, textW + 50))
+    return Math.min(440, vw, Math.max(BUBBLE_MIN_W, textW + 67))
   }
   function switchBubblePage(p) {
     currentBubblePage = p
@@ -878,13 +891,16 @@
     var activate = function (event) {
       event.preventDefault()
       event.stopPropagation()
-      // 与网页端一致（src/client.core.js activate）：占位卡不可交互，
-      // 否则点击「待机中」会以 __pet_idle__ 广播打开不存在的会话，
-      // 无网页在线时还会误触 openDshPage 弹出浏览器。
-      if (el.node.dataset.idlePlaceholder === 'true') return
+      // 桌面端空闲占位卡单击打开带 token 的 DSH 根页面，
+      // 不把 __pet_idle__ 当作真实会话发送给宿主。
+      if (el.node.dataset.idlePlaceholder === 'true') {
+        __tip.openIdleDshPage(window.petBridge)
+        return
+      }
       // 假背板：点击时按当帧排序动态解析第 2 名会话并跳转。
       if (el.targetSessionId === BUBBLE_BACKBOARD_ID) {
-        if (backboardTarget) requestSessionOpen(backboardTarget, false)
+        var target = backboardStabilizer.target()
+        if (target) requestSessionOpen(target, false)
         return
       }
       requestSessionOpen(el.targetSessionId, el.completed)
@@ -1023,7 +1039,7 @@
     // 是 0.3.4 桌面点卡片不跳转时代的遗留，与 title 提示和实际行为矛盾。
     el.node.style.cursor = entry.idlePlaceholder ? 'default' : 'pointer'
     el.node.dataset.idlePlaceholder = entry.idlePlaceholder ? 'true' : 'false'
-    // 占位卡不可交互（activate 有守卫），提示不能落进「点击跳转」兜底文案。
+    // 空闲占位卡不显示会话跳转提示；桌面端单击行为在 activate 中单独处理。
     // 审批卡悬停用第二行全文（工作区 · preview）：气泡宽度会 CSS 省略，自绘
     // 浮层才能读到请求内容；原生 title 不随 zoom 缩放已废弃；操作说明在勾号
     // aria-label 里。title 置空避免与自绘浮层双重提示。
@@ -1087,6 +1103,10 @@
     // 点击背板时按当帧排序动态解析第 2 名并跳转，这里只需记住它是谁。
     var visibleEntries = ordered.slice(0, 1)
     if (ordered.length > 1) {
+      backboardStabilizer.update(
+        targetSessionOf(ordered[1]) || '',
+        __tip.backboardTipText(ordered[1].project, ordered[1].title),
+      )
       visibleEntries.push({
         sessionId: BUBBLE_BACKBOARD_ID,
         state: 'IDLE',
@@ -1096,11 +1116,10 @@
         updatedAt: 0,
         backboard: true,
         summaryCount: ordered.length - 1,
-        backboardTip: __tip.backboardTipText(ordered[1].project, ordered[1].title),
+        backboardTip: backboardStabilizer.tip(),
       })
-      backboardTarget = targetSessionOf(ordered[1]) || ''
     } else {
-      backboardTarget = ''
+      backboardStabilizer.update('', '')
     }
     var count = visibleEntries.length
     var seen = new Set()
@@ -1112,13 +1131,13 @@
       var stackedEl = ensureBubbleEl(entry.sessionId)
       if (stackedEl.node.parentNode !== bubbleStack) bubbleStack.appendChild(stackedEl.node)
       renderBubble(stackedEl, entry, i)
-      stackedEl.node.style.minWidth = '150px'
+      stackedEl.node.style.minWidth = '200px'
       stackedEl.node.style.width = 'max-content'
       stackedEl.node.style.maxWidth = 'none'
       stackedEl.node.classList.remove('title-clipped')
       var titleWidth = stackedEl.title.scrollWidth || stackedEl.title.offsetWidth || 0
-      var actionWidth = 30
-      var completionWidth = completionOf(entry) ? 22 : 0
+      var actionWidth = 40
+      var completionWidth = completionOf(entry) ? 29 : 0
       stackedEl.naturalHeaderWidth = titleWidth + actionWidth + completionWidth
       var detailW = stackedEl.detail.scrollWidth || stackedEl.detail.offsetWidth || 0
       if (i === 0) measuredWidth = Math.max(stackedEl.naturalHeaderWidth, detailW)
@@ -1132,7 +1151,7 @@
       var renderEntry = visibleEntries[j]
       var renderEl = bubbleEls.get(renderEntry.sessionId)
       renderBubble(renderEl, renderEntry, j)
-      renderEl.node.classList.toggle('title-clipped', renderEl.naturalHeaderWidth > Math.max(0, deckWidth - 50))
+      renderEl.node.classList.toggle('title-clipped', renderEl.naturalHeaderWidth > Math.max(0, deckWidth - 67))
     }
     for (var key of bubbleEls.keys()) {
       if (!seen.has(key)) {
@@ -1153,6 +1172,8 @@
   function applyTransform(mood, snapshot) {
     var scale = snapshot.scale || 1
     imgEl.style.width = Math.round(180 * scale) + 'px'
+    bubbleEl.style.zoom = String(scale)
+    bubbleStack.style.zoom = String(scale)
     imgEl.style.transform = ''
   }
 

--- a/src/pet-window.cjs
+++ b/src/pet-window.cjs
@@ -366,7 +366,7 @@ app.whenReady().then(() => {
   })
 
   // 无网页客户端在线时点击气泡卡：渲染层只发信号，URL 由宿主经 DSH_WEB_URL
-  // 传入（DSH 0.1.2+ 为带进程 token 的根路径；旧宿主为 origin）。
+  // 传入（桌面模式要求 DSH 0.1.2-alpha.1+ 的带进程 token 根路径）。
   // 用 href 而不是 origin：token 在 query 上，303 换 cookie 时也会丢掉其它参数。
   ipcMain.handle('open-dsh-page', () => {
     try {

--- a/test/client-interactions.test.js
+++ b/test/client-interactions.test.js
@@ -11,6 +11,7 @@ function createHarness(initialCurrent = 'other', autoSelect = true, snapshotItem
   const fetches = []
   const opened = []
   const timers = []
+  let nextTimer = 0
   const styleWrites = []
   let current = initialCurrent
   let sessionListener
@@ -136,8 +137,15 @@ function createHarness(initialCurrent = 'other', autoSelect = true, snapshotItem
     removeEventListener() {},
     setInterval() { return 1 },
     clearInterval() {},
-    setTimeout(listener) { timers.push(listener); return timers.length },
-    clearTimeout() {},
+    setTimeout(listener) {
+      const id = ++nextTimer
+      timers.push({ id, listener, cancelled: false })
+      return id
+    },
+    clearTimeout(id) {
+      const timer = timers.find((entry) => entry.id === id)
+      if (timer) timer.cancelled = true
+    },
     requestAnimationFrame() { return 1 },
     cancelAnimationFrame() {},
     dispatchEvent() {},
@@ -192,7 +200,9 @@ function createHarness(initialCurrent = 'other', autoSelect = true, snapshotItem
   }
   function flushTitleTimers() {
     const queued = timers.splice(0)
-    for (const listener of queued) listener()
+    for (const timer of queued) {
+      if (!timer.cancelled) timer.listener()
+    }
   }
   function dispatchWindowEvent(name) {
     for (const listener of windowListeners.get(name) ?? []) listener({})
@@ -215,9 +225,18 @@ test('generated CSS fixes active and idle heights without margin animation', () 
   const harness = createHarness()
   const css = harness.elements.find((node) => node.tag === 'style' && node.textContent.includes('.rm2-pet-bubbles'))?.textContent
   assert.ok(css, 'missing injected pet CSS')
-  assert.match(css, /height:68px;min-height:68px/)
-  assert.match(css, /idle-placeholder\{height:46px;min-height:46px/)
+  assert.match(css, /height:91px;min-height:91px/)
+  assert.match(css, /idle-placeholder\{height:61px;min-height:61px/)
   assert.doesNotMatch(css, /transition:[^;}]*margin/)
+})
+
+test('bubble containers scale with the configured pet size', () => {
+  const harness = createHarness()
+  harness.send({ ...base, scale: 0.75 })
+  const bubble = harness.elements.find((node) => String(node.className).includes('rm2-pet-bubble') && !String(node.className).includes('rm2-pet-bubbles'))
+  const bubbleStack = harness.elements.find((node) => node.className === 'rm2-pet-bubbles')
+  assert.equal(bubble.style.zoom, '0.75')
+  assert.equal(bubbleStack.style.zoom, '0.75')
 })
 
 test('multi-session deck renders an inert backboard with a dynamic click target', () => {
@@ -249,6 +268,7 @@ test('multi-session deck renders an inert backboard with a dynamic click target'
       sessions[2],
     ],
   })
+  harness.flushTitleTimers()
   assert.equal(backboard.dataset.rm2Tip, '点击去看 dsh-pet-remielle · 审查提示框颜色与溢出问题 哦~')
   // 点击背板：按当帧排序动态解析第 2 名（second）并跳转。
   harness.click(backboard)
@@ -257,6 +277,27 @@ test('multi-session deck renders an inert backboard with a dynamic click target'
   // 先把当前会话复位回 first：上一次跳转已让 second 成为当前会话并占据首层。
   harness.select('first')
   harness.send({ ...base, sessions: [sessions[0], sessions[1], { ...sessions[2], updatedAt: 5 }] })
+  harness.flushTitleTimers()
+  harness.click(backboard)
+  assert.deepEqual(harness.opened, ['second', 'third'])
+})
+
+test('backboard target and tip stay paired while sorting settles', () => {
+  const harness = createHarness('first')
+  const mk = (id, updatedAt, title) => ({ sessionId: id, state: 'WORKING', phase: 'tool-call', message: `${id} 的消息`, title, updatedAt })
+  harness.send({ ...base, sessions: [mk('first', 30, '首个对话'), mk('second', 20, '第二个对话')] })
+  const backboard = harness.elements.find((node) => String(node.className).includes('backboard'))
+  assert.ok(backboard)
+  assert.equal(backboard.dataset.rm2Tip, '点击去看 第二个对话 哦~')
+
+  harness.send({ ...base, sessions: [mk('first', 10, '首个对话'), mk('third', 40, '第三个对话')] })
+  // 新排序先进入防抖，背板提示与点击目标仍保持上一对。
+  assert.equal(backboard.dataset.rm2Tip, '点击去看 第二个对话 哦~')
+  harness.click(backboard)
+  assert.deepEqual(harness.opened, ['second'])
+
+  harness.flushTitleTimers()
+  assert.equal(backboard.dataset.rm2Tip, '点击去看 第三个对话 哦~')
   harness.click(backboard)
   assert.deepEqual(harness.opened, ['second', 'third'])
 })

--- a/test/desktop-window.test.js
+++ b/test/desktop-window.test.js
@@ -144,6 +144,31 @@ test('DesktopWindow start is idempotent while running and fires onExit', () => {
   assert.equal(exited, 1)
 })
 
+test('DesktopWindow reports asynchronous spawn failures through onExit once', () => {
+  let exited = 0
+  let childRef
+  const window = new DesktopWindow({
+    url: 'http://127.0.0.1:1/x',
+    backend: { kind: 'electron', command: 'E:/missing/electron.exe', args: [] },
+    onExit: () => { exited += 1 },
+    logger: { error() {} },
+    spawnImpl: () => {
+      const child = new EventEmitter()
+      child.exitCode = null
+      child.killed = false
+      child.kill = () => { child.killed = true }
+      childRef = child
+      return child
+    },
+  })
+  window.start()
+  childRef.emit('error', new Error('ENOENT'))
+  assert.equal(exited, 1)
+  childRef.emit('exit', 1)
+  assert.equal(window.running, false)
+  assert.equal(exited, 1)
+})
+
 // ---------- findRoot ----------
 
 test('findRoot walks up and finds the marker', () => {

--- a/test/desktop-window.test.js
+++ b/test/desktop-window.test.js
@@ -228,8 +228,13 @@ test('pet-view ships the stacked bubble deck and a single page-switch dot', () =
   assert.match(html, /class="rm2-bubble-dot"/)
   assert.match(html, /SESSION_OPEN_ENDPOINT/)
   assert.doesNotMatch(html, /id="dot1"/)
-  assert.match(html, /height:\s*68px/)
+  assert.match(html, /height:\s*91px/)
   assert.match(html, /idle-placeholder/)
+  assert.match(html, /__tip\.openIdleDshPage\(window\.petBridge\)/)
+  assert.match(html, /BACKBOARD_TIP_DEBOUNCE_MS = 400/)
+  assert.match(html, /__tip\.createBackboardStabilizer\(/)
+  assert.match(html, /bubbleEl\.style\.zoom = String\(scale\)/)
+  assert.match(html, /bubbleStack\.style\.zoom = String\(scale\)/)
   assert.match(html, /clearPulse:\s*true/)
   // SSE 订阅带 ?client=pet：宿主据此把桌宠窗口排除在 session-action 重放计数之外
   // （与 index.js streamClientOf 的约定一致），否则"无网页在线"判定永远不成立。

--- a/test/pet-tip.test.js
+++ b/test/pet-tip.test.js
@@ -18,6 +18,53 @@ test('backboard tip joins workspace and conversation title without brackets', ()
   assert.equal(tip.backboardTipText('', ''), '点击跳到这里看一下~')
 })
 
+test('backboard stabilizer debounces paired target and tip without stale commits', () => {
+  const timers = new Map()
+  let nextTimer = 0
+  const committed = []
+  const schedule = (listener) => {
+    const id = ++nextTimer
+    timers.set(id, listener)
+    return id
+  }
+  const cancel = (id) => timers.delete(id)
+  const flush = () => {
+    const queued = [...timers.values()]
+    timers.clear()
+    for (const listener of queued) listener()
+  }
+  const stabilizer = tip.createBackboardStabilizer(
+    (target, text) => committed.push({ target, text }),
+    400,
+    schedule,
+    cancel,
+  )
+
+  stabilizer.update('A', '提示 A')
+  stabilizer.update('B', '提示 B')
+  stabilizer.update('A', '提示 A')
+  flush()
+  assert.deepEqual(committed, [{ target: 'A', text: '提示 A' }])
+  assert.equal(stabilizer.target(), 'A')
+  assert.equal(stabilizer.tip(), '提示 A')
+
+  stabilizer.update('B', '提示 B')
+  stabilizer.update('C', '提示 C')
+  flush()
+  assert.deepEqual(committed, [
+    { target: 'A', text: '提示 A' },
+    { target: 'C', text: '提示 C' },
+  ])
+})
+
+test('desktop idle action opens DSH only when the bridge exposes it', () => {
+  let calls = 0
+  assert.equal(tip.openIdleDshPage({ openDshPage() { calls += 1 } }), true)
+  assert.equal(calls, 1)
+  assert.equal(tip.openIdleDshPage({}), false)
+  assert.equal(tip.openIdleDshPage(null), false)
+})
+
 test('applyDotTip writes overlay text and clears native title', () => {
   const dot = { dataset: {}, title: '切到余额' }
   const shown = []


### PR DESCRIPTION
## 背景

DSH `0.1.2-alpha.1` 起，Web 壳根路径需要通过 `connection.authenticatedUrl(origin)` 生成带进程 token 的 URL；直接打开干净的 `http://127.0.0.1:<port>/` 会返回 401。

PR #14 已经处理了 token URL，但保留了旧宿主兼容回退。本 PR 选择明确要求 DSH `>= 0.1.2-alpha.1`，并同时整理桌面气泡交互和第二层气泡提示稳定性问题。

关联：#13、#14。

## 具体改动

### 1. 桌面 Web 壳使用认证 URL

涉及：`src/index.js`、`src/desktop-window.js`、`src/pet-window.cjs`

- `src/index.js` 将桌面 Web URL 的注入依赖从 `webServer` 改为 `webServer + connection`。
- 创建桌面窗口时调用 `httpCtx.connection.authenticatedUrl(origin)`，得到类似 `/?token=...` 的认证根 URL。
- `DSH_PET_URL` 和 `DSH_WEB_URL` 继续分开：token 只用于打开 DSH Web 壳，不拼进插件自己的 pet-view 地址。
- Electron 的 `open-dsh-page` 使用 `DSH_WEB_URL` 的完整 `href`，保留 `?token=`，然后交给系统浏览器打开。
- 不再把旧宿主的 origin 回退当作本 PR 的兼容路径；旧版本兼容实现和代码已补充到 Issue #13，交由维护者选择。

### 2. 桌面模式空闲气泡单击打开 DSH

涉及：`src/pet-tip.cjs`、`src/pet-view.html`

- 新增共享的 `openIdleDshPage(bridge)` 行为封装。
- 桌面模式下，空闲占位卡 `__pet_idle__` 被单击时调用 `window.petBridge.openDshPage()`。
- 不再把 `__pet_idle__` 当成真实会话发送 `/session/open`，因此不会产生虚假的会话打开请求。
- 网页端仍保持空闲占位卡不可交互；该行为只针对桌面悬浮窗。

### 3. 第二层气泡目标和提示文字防抖

涉及：`src/pet-tip.cjs`、`src/client.core.js`、`src/pet-view.html`、`lib/client.js`

- 新增共享的 `createBackboardStabilizer()`，由桌面页面和网页客户端共用。
- 目标 sessionId 与提示文字作为一对状态一起更新，避免出现“提示显示 A、点击实际打开 B”。
- 使用真正的 trailing debounce：每次候选目标变化都会取消旧定时器并重新计时。
- `A → B → A` 时会清除过期的 B，不会在旧定时器触发后错误跳转到 B。
- 只有稳定 400ms 后才提交第二层背板目标和提示文字；背板点击读取同一个稳定目标。
- 第一层首行文字原有的短时稳定策略保持不变，本改动专门解决第二层背板提示快速跳变问题。

### 4. 桌面窗口退出通知去重

涉及：`src/desktop-window.js`

- 将 Electron 子进程的 `error` 和 `exit` 统一收敛到一次性 `notifyExit()`。
- 无论是同步启动失败、异步 `error` 还是随后收到的 `exit`，`onExit` 都只触发一次。
- 确保退出后 `this.child` 被正确清理，避免桌面状态重复广播或残留运行状态。

### 5. 气泡尺寸、缩放和生成文件同步

涉及：`src/client.core.js`、`src/pet-view.html`、`lib/client.js`

- 调整气泡卡、背板、操作按钮和完成标记的尺寸，使桌面和网页端的气泡布局一致。
- 根据宠物缩放值同步缩放气泡容器，不再只缩放宠物图片。
- 保留现有的圆角视觉和布局调整。
- 运行 `npm run build:client` 重新生成 `lib/client.js`，确保发布 bundle 与源码一致。

## 测试覆盖

新增或更新了以下验证：

- `test/pet-tip.test.js`
  - 背板目标/提示成对提交；
  - `A → B → A` 不提交过期目标；
  - 空闲桌面动作只在 bridge 提供 `openDshPage()` 时触发。
- `test/client-interactions.test.js`
  - 背板目标在防抖期间保持原目标；
  - 防抖完成后提示和点击目标一起切换；
  - 定时器取消行为；
  - 气泡容器跟随宠物缩放。
- `test/desktop-window.test.js`
  - `DSH_WEB_URL` origin 和带 token URL 的环境变量下发；
  - 异步启动失败时 `onExit` 只触发一次；
  - 桌面页面包含空闲点击、背板防抖和缩放逻辑。

验证结果：

- 定向测试：60 通过，1 跳过，0 失败；
- `npm run check`：通过；
- `npm run build:client`：通过且无额外差异；
- 完整测试：147 通过，1 跳过；2 个用例因本地缺少 `@deepseek-ai/schemastery` 无法加载，不是本次功能断言失败；
- 本机端到端：无网页客户端在线时，单击桌面空闲气泡可以打开系统浏览器并正常进入 DSH Web 壳，已确认带 token 的认证链路生效。

## 兼容策略

本 PR 的最低要求是 DSH `>= 0.1.2-alpha.1`。如果需要继续支持旧宿主，Issue #13 中列出了完整的可选兼容方案：只在 `connection` 服务或 `authenticatedUrl()` 方法不存在时回退 origin，不吞掉新宿主认证方法的真实异常，并保持 `DSH_PET_URL` / `DSH_WEB_URL` 分离。

## 未包含

- 不把 token 写入 `DSH_PET_URL`、日志或测试快照；
- 不修改 DSH 宿主本身；
- 不在本 PR 中重新引入旧宿主兼容回退。
